### PR TITLE
Add metrics on time since ingestion

### DIFF
--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -213,6 +214,14 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	}
 	if delivery.Messages[0].ReceiptHandle != nil {
 		sig.SQSReceiptHandle = *delivery.Messages[0].ReceiptHandle
+	}
+
+	sentTimeSinceEpochMilliString := delivery.Messages[0].Attributes[awssqs.MessageSystemAttributeNameSentTimestamp]
+	if sentTimeSinceEpochMilliString != nil {
+		if i, err := strconv.ParseInt(*sentTimeSinceEpochMilliString, 10, 64); err == nil {
+			t := time.UnixMilli(i)
+			sig.IngestionTime = &t
+		}
 	}
 
 	// If the task is not registered return an error

--- a/v1/tasks/signature.go
+++ b/v1/tasks/signature.go
@@ -48,6 +48,7 @@ type Signature struct {
 	Name           string
 	RoutingKey     string
 	ETA            *time.Time
+	IngestionTime  *time.Time
 	GroupUUID      string
 	GroupTaskCount int
 	Args           []Arg


### PR DESCRIPTION
<img width="409" alt="Screen Shot 2021-09-27 at 1 03 44 PM" src="https://user-images.githubusercontent.com/88673576/134977230-886ef1fb-def2-478d-b2ca-cfe8b7423d77.png">

(I changed the names but you get the idea)

This will be an attribute on a span, not a span itself. We should still be able to graph that, supposedly.