### PR TITLE
Allow extending SQS message visibility

### DIFF
--- a/v1/brokers/eager/eager.go
+++ b/v1/brokers/eager/eager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/RichardKnop/machinery/v1/brokers/iface"
 	"github.com/RichardKnop/machinery/v1/common"
@@ -59,7 +60,12 @@ func (eagerBroker *Broker) Publish(ctx context.Context, task *tasks.Signature) e
 	}
 
 	// blocking call to the task directly
-	return eagerBroker.worker.Process(signature)
+	return eagerBroker.worker.Process(signature, eagerBroker.extend)
+}
+
+func (b *Broker) extend(time.Duration, *tasks.Signature) error {
+	// Unclear what this behavior should be -- consuming isn't supported.
+	return fmt.Errorf("eager broker does not support extending")
 }
 
 // AssignWorker assigns a worker to the eager broker

--- a/v1/brokers/iface/interfaces.go
+++ b/v1/brokers/iface/interfaces.go
@@ -23,7 +23,7 @@ type Broker interface {
 // TaskProcessor - can process a delivered task
 // This will probably always be a worker instance
 type TaskProcessor interface {
-	Process(signature *tasks.Signature) error
+	Process(signature *tasks.Signature, extendFunc tasks.ExtendForSignatureFunc) error
 	CustomQueue() string
 	PreConsumeHandler() bool
 }

--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -204,6 +204,12 @@ func (b *BrokerGR) Publish(ctx context.Context, signature *tasks.Signature) erro
 	return err
 }
 
+func (b *BrokerGR) extend(time.Duration, *tasks.Signature) error {
+	// Tasks don't need to be extended with redis because messages won't become available again if they're not
+	// acked/deleted.
+	return nil
+}
+
 // GetPendingTasks returns a slice of task signatures waiting in the queue
 func (b *BrokerGR) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
 
@@ -314,7 +320,7 @@ func (b *BrokerGR) consumeOne(delivery []byte, taskProcessor iface.TaskProcessor
 
 	log.DEBUG.Printf("Received new message: %s", delivery)
 
-	return taskProcessor.Process(signature)
+	return taskProcessor.Process(signature, b.extend)
 }
 
 // nextTask pops next available task from the default queue

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -216,6 +216,12 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	return err
 }
 
+func (b *Broker) extend(time.Duration, *tasks.Signature) error {
+	// Tasks don't need to be extended with redis because messages won't become available again if they're not
+	// acked/deleted.
+	return nil
+}
+
 // GetPendingTasks returns a slice of task signatures waiting in the queue
 func (b *Broker) GetPendingTasks(queue string) ([]*tasks.Signature, error) {
 	conn := b.open()
@@ -346,7 +352,7 @@ func (b *Broker) consumeOne(delivery []byte, taskProcessor iface.TaskProcessor) 
 
 	log.DEBUG.Printf("Received new message: %s", delivery)
 
-	return taskProcessor.Process(signature)
+	return taskProcessor.Process(signature, b.extend)
 }
 
 // nextTask pops next available task from the default queue

--- a/v1/tasks/task_test.go
+++ b/v1/tasks/task_test.go
@@ -120,7 +120,7 @@ func TestTaskCallWithSignatureInContext(t *testing.T) {
 	}
 	signature, err := tasks.NewSignature("foo", []tasks.Arg{})
 	assert.NoError(t, err)
-	task, err := tasks.NewWithSignature(f, signature)
+	task, err := tasks.NewWithSignature(f, signature, func(time.Duration, *tasks.Signature) error { return nil })
 	assert.NoError(t, err)
 	taskResults, err := task.Call()
 	assert.NoError(t, err)

--- a/v1/worker.go
+++ b/v1/worker.go
@@ -133,7 +133,7 @@ func (worker *Worker) Quit() {
 }
 
 // Process handles received tasks and triggers success/error callbacks
-func (worker *Worker) Process(signature *tasks.Signature) error {
+func (worker *Worker) Process(signature *tasks.Signature, extendFunc tasks.ExtendForSignatureFunc) error {
 	// If the task is not registered with this worker, do not continue
 	// but only return nil as we do not want to restart the worker process
 	if !worker.server.IsTaskRegistered(signature.Name) {
@@ -151,7 +151,7 @@ func (worker *Worker) Process(signature *tasks.Signature) error {
 	}
 
 	// Prepare task for processing
-	task, err := tasks.NewWithSignature(taskFunc, signature)
+	task, err := tasks.NewWithSignature(taskFunc, signature, extendFunc)
 	// if this failed, it means the task is malformed, probably has invalid
 	// signature, go directly to task failed without checking whether to retry
 	if err != nil {


### PR DESCRIPTION
* Behavior varies for non-SQS implementations, and may not be totally
correct (fine for us).
* Context object used to plumb through the function.

---

Tested locally and this behaves as expected.