### PR TITLE
Restore RetryCount behavior and add AttemptCount

### DIFF
--- a/v1/brokers/sqs/sqs_test.go
+++ b/v1/brokers/sqs/sqs_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/RichardKnop/machinery/v1/brokers/iface"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 
@@ -34,6 +36,12 @@ func TestNewAWSSQSBroker(t *testing.T) {
 	broker := sqs.NewTestBroker()
 
 	assert.IsType(t, broker, sqs.New(cnf))
+
+	// Really a compilation test
+	var asRetry iface.RetrySameMessage
+	asRetry = broker
+
+	assert.NotNil(t, asRetry)
 }
 
 func TestPrivateFunc_continueReceivingMessages(t *testing.T) {

--- a/v1/tasks/signature.go
+++ b/v1/tasks/signature.go
@@ -56,7 +56,8 @@ type Signature struct {
 	Headers        Headers
 	Priority       uint8
 	Immutable      bool
-	RetryCount     int
+	RetryCount     int // Remaining retries
+	AttemptCount   int // Attempts (starting at 0 for convenience)
 	RetryTimeout   int
 	SplitSpan      bool
 	OnSuccess      []*Signature


### PR DESCRIPTION
RetryCount was used incorrectly, leading to default retry behavior
after app defined retries had run out. This eventually leads to
SQS max delay exceeded errors.

Includes some other minor logging + safety changes.