### PR TITLE
Return to pool when no tasks received

### DIFF
--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -110,6 +110,8 @@ func (b *BrokerGR) StartConsuming(consumerTag string, concurrency iface.Resizeab
 				//TODO: should this error be ignored?
 				if len(task) > 0 {
 					deliveries <- task
+				} else {
+					concurrency.Return()
 				}
 			}
 		}

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -115,6 +115,8 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 					//TODO: should this error be ignored?
 					if len(task) > 0 {
 						deliveries <- task
+					} else {
+						concurrency.Return()
 					}
 				}
 			}


### PR DESCRIPTION
nextTask does not always return results. When no results
are returned nothing is sent to deliveries (which normally
returns to the pool).