### PR TITLE
Resizable Concurrency Pool Fix

### DIFF
--- a/test_results
+++ b/test_results
@@ -2,16 +2,16 @@
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
 
 
-At capacity 97.92 %
-Below capacity 0.69 %
-Above capacity 1.39 %  
+At capacity 97.32 %
+Below capacity 0.67 %
+Above capacity 2.01 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
 
 
-At capacity 100.00 %
-Below capacity 0.00 %
+At capacity 99.26 %
+Below capacity 0.74 %
 Above capacity 0.00 %  
 ----
 
@@ -26,25 +26,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
 
 
-At capacity 59.79 %
-Below capacity 3.09 %
-Above capacity 37.11 %  
+At capacity 68.69 %
+Below capacity 5.05 %
+Above capacity 26.26 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
 
 
-At capacity 36.46 %
-Below capacity 1.04 %
-Above capacity 62.50 %  
+At capacity 42.27 %
+Below capacity 4.12 %
+Above capacity 53.61 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
 
 
-At capacity 60.92 %
-Below capacity 6.90 %
-Above capacity 32.18 %  
+At capacity 51.69 %
+Below capacity 3.37 %
+Above capacity 44.94 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
@@ -58,25 +58,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
 
 
-At capacity 68.18 %
-Below capacity 4.55 %
-Above capacity 27.27 %  
+At capacity 71.26 %
+Below capacity 5.75 %
+Above capacity 22.99 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
 
 
-At capacity 82.14 %
-Below capacity 2.38 %
-Above capacity 15.48 %  
+At capacity 89.41 %
+Below capacity 1.18 %
+Above capacity 9.41 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
 
 
-At capacity 80.90 %
-Below capacity 1.12 %
-Above capacity 17.98 %  
+At capacity 87.95 %
+Below capacity 2.41 %
+Above capacity 9.64 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
@@ -130,72 +130,72 @@ Above capacity NaN %
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
 
 
-At capacity 34.52 %
-Below capacity 2.38 %
-Above capacity 63.10 %  
+At capacity 35.96 %
+Below capacity 4.49 %
+Above capacity 59.55 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
 
 
-At capacity 40.26 %
-Below capacity 3.90 %
-Above capacity 55.84 %  
+At capacity 38.10 %
+Below capacity 8.33 %
+Above capacity 53.57 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
 
 
-At capacity 30.59 %
-Below capacity 3.53 %
-Above capacity 65.88 %  
+At capacity 39.51 %
+Below capacity 11.11 %
+Above capacity 49.38 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
 
 
-At capacity 45.00 %
-Below capacity 5.00 %
-Above capacity 50.00 %  
+At capacity 45.57 %
+Below capacity 7.59 %
+Above capacity 46.84 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
 
 
-At capacity 35.00 %
-Below capacity 2.50 %
-Above capacity 62.50 %  
+At capacity 39.51 %
+Below capacity 11.11 %
+Above capacity 49.38 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
 
 
-At capacity 46.25 %
-Below capacity 3.75 %
-Above capacity 50.00 %  
+At capacity 44.05 %
+Below capacity 7.14 %
+Above capacity 48.81 %  
 ----
 
 
 Rolling Results.
 WorstAboveCap 
 rolling. Sleep 1s
-At capacity 36.46 %
-Below capacity 1.04 %
-Above capacity 62.50 %  
+At capacity 42.27 %
+Below capacity 4.12 %
+Above capacity 53.61 %  
 ----
 
 WorstNotAtCap 
 rolling. Sleep 1s
-At capacity 36.46 %
-Below capacity 1.04 %
-Above capacity 62.50 %  
+At capacity 42.27 %
+Below capacity 4.12 %
+Above capacity 53.61 %  
 ----
 
 Avg 
 
-At capacity 80.26 %
-Below capacity 1.80 %
-Above capacity 17.94 %  
+At capacity 82.14 %
+Below capacity 2.20 %
+Above capacity 15.67 %  
 ----
 
 
@@ -216,72 +216,72 @@ Above capacity NaN %
 
 Avg 
 
-At capacity 38.48 %
-Below capacity 3.50 %
-Above capacity 58.02 %  
+At capacity 40.36 %
+Below capacity 8.23 %
+Above capacity 51.41 %  
 ----
 
 
 Combined Results.
 WorstAboveCap 
-Constant cap at 2. Sleep 1.1s
-At capacity 30.59 %
-Below capacity 3.53 %
-Above capacity 65.88 %  
+Constant cap at 2. Sleep 1s
+At capacity 35.96 %
+Below capacity 4.49 %
+Above capacity 59.55 %  
 ----
 
 WorstNotAtCap 
-Constant cap at 2. Sleep 1.1s
-At capacity 30.59 %
-Below capacity 3.53 %
-Above capacity 65.88 %  
+Constant cap at 2. Sleep 1s
+At capacity 35.96 %
+Below capacity 4.49 %
+Above capacity 59.55 %  
 ----
 
 Avg 
 
-At capacity 66.58 %
-Below capacity 2.36 %
-Above capacity 31.06 %  
+At capacity 68.27 %
+Below capacity 4.20 %
+Above capacity 27.53 %  
 ----
 
---- PASS: TestResizablePoolConcurrency (666.64s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (35.89s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.54s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.78s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.11s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.07s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.07s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.76s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.07s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.62s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.09s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.08s)
+--- PASS: TestResizablePoolConcurrency (667.53s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.33s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.95s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.77s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.08s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.05s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.08s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.60s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.11s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.05s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.76s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.13s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.68s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.14s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.70s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.11s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.08s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.76s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.06s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.75s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.11s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.68s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.13s)
 === RUN   TestResizablePoolConcurrency
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
 
 
-At capacity 98.61 %
-Below capacity 0.69 %
-Above capacity 0.69 %  
+At capacity 95.95 %
+Below capacity 1.35 %
+Above capacity 2.70 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
 
 
-At capacity 98.53 %
+At capacity 99.26 %
 Below capacity 0.00 %
-Above capacity 1.47 %  
+Above capacity 0.74 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
@@ -295,25 +295,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
 
 
-At capacity 77.78 %
-Below capacity 2.02 %
-Above capacity 20.20 %  
+At capacity 82.61 %
+Below capacity 3.26 %
+Above capacity 14.13 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
 
 
-At capacity 47.92 %
-Below capacity 2.08 %
-Above capacity 50.00 %  
+At capacity 38.46 %
+Below capacity 4.81 %
+Above capacity 56.73 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
 
 
-At capacity 27.17 %
-Below capacity 1.09 %
-Above capacity 71.74 %  
+At capacity 43.53 %
+Below capacity 12.94 %
+Above capacity 43.53 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
@@ -327,25 +327,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
 
 
-At capacity 75.28 %
+At capacity 76.40 %
 Below capacity 1.12 %
-Above capacity 23.60 %  
+Above capacity 22.47 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
 
 
-At capacity 86.90 %
-Below capacity 0.00 %
-Above capacity 13.10 %  
+At capacity 90.00 %
+Below capacity 2.50 %
+Above capacity 7.50 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
 
 
-At capacity 87.06 %
+At capacity 91.57 %
 Below capacity 0.00 %
-Above capacity 12.94 %  
+Above capacity 8.43 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
@@ -399,72 +399,72 @@ Above capacity NaN %
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
 
 
-At capacity 28.72 %
-Below capacity 0.00 %
-Above capacity 71.28 %  
+At capacity 40.45 %
+Below capacity 4.49 %
+Above capacity 55.06 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
 
 
-At capacity 37.33 %
-Below capacity 5.33 %
-Above capacity 57.33 %  
+At capacity 45.00 %
+Below capacity 2.50 %
+Above capacity 52.50 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
 
 
-At capacity 40.00 %
-Below capacity 0.00 %
-Above capacity 60.00 %  
+At capacity 39.02 %
+Below capacity 9.76 %
+Above capacity 51.22 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
 
 
-At capacity 45.12 %
-Below capacity 2.44 %
-Above capacity 52.44 %  
+At capacity 39.51 %
+Below capacity 8.64 %
+Above capacity 51.85 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
 
 
-At capacity 32.14 %
-Below capacity 0.00 %
-Above capacity 67.86 %  
+At capacity 58.67 %
+Below capacity 6.67 %
+Above capacity 34.67 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
 
 
-At capacity 43.37 %
-Below capacity 2.41 %
-Above capacity 54.22 %  
+At capacity 50.63 %
+Below capacity 7.59 %
+Above capacity 41.77 %  
 ----
 
 
 Rolling Results.
 WorstAboveCap 
-rolling. Sleep 1.001s
-At capacity 27.17 %
-Below capacity 1.09 %
-Above capacity 71.74 %  
+rolling. Sleep 1s
+At capacity 38.46 %
+Below capacity 4.81 %
+Above capacity 56.73 %  
 ----
 
 WorstNotAtCap 
-rolling. Sleep 1.001s
-At capacity 27.17 %
-Below capacity 1.09 %
-Above capacity 71.74 %  
+rolling. Sleep 1s
+At capacity 38.46 %
+Below capacity 4.81 %
+Above capacity 56.73 %  
 ----
 
 Avg 
 
-At capacity 81.34 %
-Below capacity 0.70 %
-Above capacity 17.96 %  
+At capacity 82.80 %
+Below capacity 2.41 %
+Above capacity 14.79 %  
 ----
 
 
@@ -485,56 +485,56 @@ Above capacity NaN %
 
 Avg 
 
-At capacity 37.55 %
-Below capacity 1.61 %
-Above capacity 60.84 %  
+At capacity 45.27 %
+Below capacity 6.58 %
+Above capacity 48.15 %  
 ----
 
 
 Combined Results.
 WorstAboveCap 
-rolling. Sleep 1.001s
-At capacity 27.17 %
-Below capacity 1.09 %
-Above capacity 71.74 %  
+rolling. Sleep 1s
+At capacity 38.46 %
+Below capacity 4.81 %
+Above capacity 56.73 %  
 ----
 
 WorstNotAtCap 
-rolling. Sleep 1.001s
-At capacity 27.17 %
-Below capacity 1.09 %
-Above capacity 71.74 %  
+rolling. Sleep 1s
+At capacity 38.46 %
+Below capacity 4.81 %
+Above capacity 56.73 %  
 ----
 
 Avg 
 
-At capacity 66.80 %
-Below capacity 1.00 %
-Above capacity 32.20 %  
+At capacity 70.47 %
+Below capacity 3.78 %
+Above capacity 25.74 %  
 ----
 
---- PASS: TestResizablePoolConcurrency (666.70s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (35.94s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.45s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.74s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.12s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.08s)
+--- PASS: TestResizablePoolConcurrency (666.97s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.06s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.77s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.71s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.05s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.07s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.77s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.09s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.62s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.61s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.09s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.05s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.11s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.78s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.18s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.71s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.07s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.07s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.76s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.12s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.69s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.11s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.75s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.77s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.15s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.66s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.09s)
 PASS
-ok  	github.com/RichardKnop/machinery/v1/common	1333.836s
+ok  	github.com/RichardKnop/machinery/v1/common	1335.091s

--- a/test_results
+++ b/test_results
@@ -1,0 +1,540 @@
+=== RUN   TestResizablePoolConcurrency
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
+
+
+At capacity 98.57 %
+Below capacity 0.71 %
+Above capacity 0.71 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
+
+
+At capacity 99.24 %
+Below capacity 0.00 %
+Above capacity 0.76 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
+
+
+At capacity 57.58 %
+Below capacity 1.01 %
+Above capacity 41.41 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
+
+
+At capacity 31.90 %
+Below capacity 2.59 %
+Above capacity 65.52 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
+
+
+At capacity 32.35 %
+Below capacity 0.98 %
+Above capacity 66.67 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
+
+
+At capacity 64.84 %
+Below capacity 1.10 %
+Above capacity 34.07 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
+
+
+At capacity 90.24 %
+Below capacity 1.22 %
+Above capacity 8.54 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
+
+
+At capacity 97.53 %
+Below capacity 0.00 %
+Above capacity 2.47 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
+
+
+At capacity 43.21 %
+Below capacity 0.00 %
+Above capacity 56.79 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
+
+
+At capacity 40.26 %
+Below capacity 3.90 %
+Above capacity 55.84 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
+
+
+At capacity 36.25 %
+Below capacity 1.25 %
+Above capacity 62.50 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
+
+
+At capacity 34.15 %
+Below capacity 1.22 %
+Above capacity 64.63 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
+
+
+At capacity 40.51 %
+Below capacity 0.00 %
+Above capacity 59.49 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
+
+
+At capacity 24.14 %
+Below capacity 1.15 %
+Above capacity 74.71 %  
+----
+
+
+Rolling Results.
+WorstAboveCap 
+rolling. Sleep 1.001s
+At capacity 32.35 %
+Below capacity 0.98 %
+Above capacity 66.67 %  
+----
+
+WorstNotAtCap 
+rolling. Sleep 1s
+At capacity 31.90 %
+Below capacity 2.59 %
+Above capacity 65.52 %  
+----
+
+Avg 
+
+At capacity 76.96 %
+Below capacity 0.78 %
+Above capacity 22.25 %  
+----
+
+
+Constant Results.
+WorstAboveCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+WorstNotAtCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+Avg 
+
+At capacity 36.21 %
+Below capacity 1.23 %
+Above capacity 62.55 %  
+----
+
+
+Combined Results.
+WorstAboveCap 
+Constant cap at 2. Sleep 600ms
+At capacity 24.14 %
+Below capacity 1.15 %
+Above capacity 74.71 %  
+----
+
+WorstNotAtCap 
+Constant cap at 2. Sleep 600ms
+At capacity 24.14 %
+Below capacity 1.15 %
+Above capacity 74.71 %  
+----
+
+Avg 
+
+At capacity 63.81 %
+Below capacity 0.93 %
+Above capacity 35.26 %  
+----
+
+--- PASS: TestResizablePoolConcurrency (665.56s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (34.88s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.01s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (31.01s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.13s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.09s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.08s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.80s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.08s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.61s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.78s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.14s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.71s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.13s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.11s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.67s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.12s)
+=== RUN   TestResizablePoolConcurrency
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
+
+
+At capacity 95.17 %
+Below capacity 0.00 %
+Above capacity 4.83 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
+
+
+At capacity 97.79 %
+Below capacity 0.74 %
+Above capacity 1.47 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
+
+
+At capacity 65.62 %
+Below capacity 0.00 %
+Above capacity 34.38 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
+
+
+At capacity 40.21 %
+Below capacity 2.06 %
+Above capacity 57.73 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
+
+
+At capacity 46.24 %
+Below capacity 1.08 %
+Above capacity 52.69 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
+
+
+At capacity 63.22 %
+Below capacity 4.60 %
+Above capacity 32.18 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
+
+
+At capacity 86.59 %
+Below capacity 1.22 %
+Above capacity 12.20 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
+
+
+At capacity 83.72 %
+Below capacity 0.00 %
+Above capacity 16.28 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
+
+
+At capacity 39.02 %
+Below capacity 0.00 %
+Above capacity 60.98 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
+
+
+At capacity 32.53 %
+Below capacity 2.41 %
+Above capacity 65.06 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
+
+
+At capacity 45.57 %
+Below capacity 2.53 %
+Above capacity 51.90 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
+
+
+At capacity 30.49 %
+Below capacity 1.22 %
+Above capacity 68.29 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
+
+
+At capacity 36.90 %
+Below capacity 0.00 %
+Above capacity 63.10 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
+
+
+At capacity 35.37 %
+Below capacity 0.00 %
+Above capacity 64.63 %  
+----
+
+
+Rolling Results.
+WorstAboveCap 
+rolling. Sleep 1s
+At capacity 40.21 %
+Below capacity 2.06 %
+Above capacity 57.73 %  
+----
+
+WorstNotAtCap 
+rolling. Sleep 1s
+At capacity 40.21 %
+Below capacity 2.06 %
+Above capacity 57.73 %  
+----
+
+Avg 
+
+At capacity 79.18 %
+Below capacity 0.90 %
+Above capacity 19.92 %  
+----
+
+
+Constant Results.
+WorstAboveCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+WorstNotAtCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+Avg 
+
+At capacity 36.59 %
+Below capacity 1.02 %
+Above capacity 62.40 %  
+----
+
+
+Combined Results.
+WorstAboveCap 
+Constant cap at 2. Sleep 500ms
+At capacity 30.49 %
+Below capacity 1.22 %
+Above capacity 68.29 %  
+----
+
+WorstNotAtCap 
+Constant cap at 2. Sleep 500ms
+At capacity 30.49 %
+Below capacity 1.22 %
+Above capacity 68.29 %  
+----
+
+Avg 
+
+At capacity 65.12 %
+Below capacity 0.94 %
+Above capacity 33.94 %  
+----
+
+--- PASS: TestResizablePoolConcurrency (666.12s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (35.56s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.26s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.85s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.11s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.06s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.08s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.74s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.11s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.62s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.07s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.69s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.07s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.75s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.68s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.09s)
+PASS
+ok  	github.com/RichardKnop/machinery/v1/common	1332.153s

--- a/test_results
+++ b/test_results
@@ -2,17 +2,17 @@
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
 
 
-At capacity 98.65 %
-Below capacity 0.00 %
+At capacity 97.30 %
+Below capacity 1.35 %
 Above capacity 1.35 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
 
 
-At capacity 95.59 %
-Below capacity 1.47 %
-Above capacity 2.94 %  
+At capacity 97.86 %
+Below capacity 0.71 %
+Above capacity 1.43 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
@@ -26,25 +26,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
 
 
-At capacity 85.71 %
-Below capacity 4.40 %
-Above capacity 9.89 %  
+At capacity 85.39 %
+Below capacity 7.87 %
+Above capacity 6.74 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
 
 
-At capacity 59.46 %
-Below capacity 16.22 %
-Above capacity 24.32 %  
+At capacity 65.71 %
+Below capacity 20.00 %
+Above capacity 14.29 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
 
 
-At capacity 73.97 %
-Below capacity 12.33 %
-Above capacity 13.70 %  
+At capacity 85.29 %
+Below capacity 8.82 %
+Above capacity 5.88 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
@@ -58,25 +58,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
 
 
-At capacity 82.14 %
-Below capacity 5.95 %
-Above capacity 11.90 %  
+At capacity 88.89 %
+Below capacity 4.94 %
+Above capacity 6.17 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
 
 
-At capacity 88.10 %
-Below capacity 1.19 %
-Above capacity 10.71 %  
+At capacity 93.83 %
+Below capacity 3.70 %
+Above capacity 2.47 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
 
 
-At capacity 91.57 %
-Below capacity 2.41 %
-Above capacity 6.02 %  
+At capacity 98.75 %
+Below capacity 0.00 %
+Above capacity 1.25 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
@@ -130,48 +130,317 @@ Above capacity NaN %
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
 
 
-At capacity 70.31 %
-Below capacity 9.38 %
-Above capacity 20.31 %  
+At capacity 77.42 %
+Below capacity 11.29 %
+Above capacity 11.29 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
 
 
-At capacity 66.13 %
-Below capacity 12.90 %
-Above capacity 20.97 %  
+At capacity 75.00 %
+Below capacity 20.00 %
+Above capacity 5.00 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
 
 
-At capacity 52.11 %
-Below capacity 8.45 %
-Above capacity 39.44 %  
+At capacity 75.41 %
+Below capacity 13.11 %
+Above capacity 11.48 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
 
 
-At capacity 59.70 %
-Below capacity 14.93 %
-Above capacity 25.37 %  
+At capacity 71.43 %
+Below capacity 17.46 %
+Above capacity 11.11 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
 
 
-At capacity 75.00 %
-Below capacity 14.06 %
-Above capacity 10.94 %  
+At capacity 83.61 %
+Below capacity 14.75 %
+Above capacity 1.64 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
 
 
-At capacity 72.31 %
-Below capacity 9.23 %
+At capacity 73.44 %
+Below capacity 15.62 %
+Above capacity 10.94 %  
+----
+
+
+Rolling Results.
+WorstAboveCap 
+rolling. Sleep 1s
+At capacity 65.71 %
+Below capacity 20.00 %
+Above capacity 14.29 %  
+----
+
+WorstNotAtCap 
+rolling. Sleep 1s
+At capacity 65.71 %
+Below capacity 20.00 %
+Above capacity 14.29 %  
+----
+
+Avg 
+
+At capacity 92.61 %
+Below capacity 3.96 %
+Above capacity 3.43 %  
+----
+
+
+Constant Results.
+WorstAboveCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+WorstNotAtCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+Avg 
+
+At capacity 76.01 %
+Below capacity 15.36 %
+Above capacity 8.63 %  
+----
+
+
+Combined Results.
+WorstAboveCap 
+rolling. Sleep 1s
+At capacity 65.71 %
+Below capacity 20.00 %
+Above capacity 14.29 %  
+----
+
+WorstNotAtCap 
+rolling. Sleep 1s
+At capacity 65.71 %
+Below capacity 20.00 %
+Above capacity 14.29 %  
+----
+
+Avg 
+
+At capacity 87.89 %
+Below capacity 7.20 %
+Above capacity 4.90 %  
+----
+
+--- PASS: TestResizablePoolConcurrency (668.17s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.95s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.44s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.56s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.09s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.06s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.06s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.74s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.07s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.60s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.07s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.11s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.67s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.06s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.07s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.66s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.07s)
+=== RUN   TestResizablePoolConcurrency
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
+
+
+At capacity 96.03 %
+Below capacity 1.99 %
+Above capacity 1.99 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
+
+
+At capacity 97.86 %
+Below capacity 0.71 %
+Above capacity 1.43 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
+
+
+At capacity 85.23 %
+Below capacity 4.55 %
+Above capacity 10.23 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
+
+
+At capacity 62.86 %
+Below capacity 20.00 %
+Above capacity 17.14 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
+
+
+At capacity 81.94 %
+Below capacity 8.33 %
+Above capacity 9.72 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
+
+
+At capacity 84.34 %
+Below capacity 8.43 %
+Above capacity 7.23 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
+
+
+At capacity 93.83 %
+Below capacity 0.00 %
+Above capacity 6.17 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
+
+
+At capacity 96.25 %
+Below capacity 2.50 %
+Above capacity 1.25 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
+
+
+At capacity 74.19 %
+Below capacity 19.35 %
+Above capacity 6.45 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
+
+
+At capacity 81.67 %
+Below capacity 10.00 %
+Above capacity 8.33 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
+
+
+At capacity 78.69 %
+Below capacity 14.75 %
+Above capacity 6.56 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
+
+
+At capacity 79.03 %
+Below capacity 17.74 %
+Above capacity 3.23 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
+
+
+At capacity 77.05 %
+Below capacity 21.31 %
+Above capacity 1.64 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
+
+
+At capacity 73.85 %
+Below capacity 7.69 %
 Above capacity 18.46 %  
 ----
 
@@ -179,23 +448,23 @@ Above capacity 18.46 %
 Rolling Results.
 WorstAboveCap 
 rolling. Sleep 1s
-At capacity 59.46 %
-Below capacity 16.22 %
-Above capacity 24.32 %  
+At capacity 62.86 %
+Below capacity 20.00 %
+Above capacity 17.14 %  
 ----
 
 WorstNotAtCap 
 rolling. Sleep 1s
-At capacity 59.46 %
-Below capacity 16.22 %
-Above capacity 24.32 %  
+At capacity 62.86 %
+Below capacity 20.00 %
+Above capacity 17.14 %  
 ----
 
 Avg 
 
-At capacity 89.26 %
-Below capacity 3.68 %
-Above capacity 7.05 %  
+At capacity 91.30 %
+Below capacity 3.93 %
+Above capacity 4.78 %  
 ----
 
 
@@ -216,325 +485,56 @@ Above capacity NaN %
 
 Avg 
 
-At capacity 65.65 %
-Below capacity 11.45 %
-Above capacity 22.90 %  
+At capacity 77.36 %
+Below capacity 15.09 %
+Above capacity 7.55 %  
 ----
 
 
 Combined Results.
 WorstAboveCap 
-Constant cap at 2. Sleep 1.1s
-At capacity 52.11 %
-Below capacity 8.45 %
-Above capacity 39.44 %  
-----
-
-WorstNotAtCap 
-Constant cap at 2. Sleep 1.1s
-At capacity 52.11 %
-Below capacity 8.45 %
-Above capacity 39.44 %  
-----
-
-Avg 
-
-At capacity 82.35 %
-Below capacity 5.96 %
-Above capacity 11.69 %  
-----
-
---- PASS: TestResizablePoolConcurrency (667.32s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.19s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.05s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.70s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.13s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.07s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.75s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.09s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.62s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.09s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.07s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.11s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.75s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.70s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.11s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.05s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.07s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.77s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.07s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.68s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.09s)
-=== RUN   TestResizablePoolConcurrency
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
-
-
-At capacity 100.00 %
-Below capacity 0.00 %
-Above capacity 0.00 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
-
-
-At capacity 97.86 %
-Below capacity 0.00 %
-Above capacity 2.14 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
-
-
-At capacity 100.00 %
-Below capacity 0.00 %
-Above capacity 0.00 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
-
-
-At capacity 81.11 %
-Below capacity 4.44 %
-Above capacity 14.44 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
-
-
-At capacity 72.22 %
-Below capacity 13.89 %
-Above capacity 13.89 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
-
-
-At capacity 79.49 %
-Below capacity 5.13 %
-Above capacity 15.38 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
-
-
-At capacity 100.00 %
-Below capacity 0.00 %
-Above capacity 0.00 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
-
-
-At capacity 78.05 %
-Below capacity 3.66 %
-Above capacity 18.29 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
-
-
-At capacity 91.57 %
-Below capacity 2.41 %
-Above capacity 6.02 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
-
-
-At capacity 92.68 %
-Below capacity 3.66 %
-Above capacity 3.66 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
-
-
-At capacity 61.54 %
+Constant cap at 2. Sleep 600ms
+At capacity 73.85 %
 Below capacity 7.69 %
-Above capacity 30.77 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
-
-
-At capacity 66.67 %
-Below capacity 11.11 %
-Above capacity 22.22 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
-
-
-At capacity 58.82 %
-Below capacity 11.76 %
-Above capacity 29.41 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
-
-
-At capacity 64.71 %
-Below capacity 8.82 %
-Above capacity 26.47 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
-
-
-At capacity 63.24 %
-Below capacity 10.29 %
-Above capacity 26.47 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
-
-
-At capacity 76.92 %
-Below capacity 9.23 %
-Above capacity 13.85 %  
-----
-
-
-Rolling Results.
-WorstAboveCap 
-rolling. Sleep 500ms
-At capacity 78.05 %
-Below capacity 3.66 %
-Above capacity 18.29 %  
+Above capacity 18.46 %  
 ----
 
 WorstNotAtCap 
 rolling. Sleep 1s
-At capacity 72.22 %
-Below capacity 13.89 %
-Above capacity 13.89 %  
+At capacity 62.86 %
+Below capacity 20.00 %
+Above capacity 17.14 %  
 ----
 
 Avg 
 
-At capacity 90.86 %
-Below capacity 2.73 %
-Above capacity 6.41 %  
+At capacity 87.36 %
+Below capacity 7.08 %
+Above capacity 5.56 %  
 ----
 
-
-Constant Results.
-WorstAboveCap 
-Constant cap at 0. Sleep 1s
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-WorstNotAtCap 
-Constant cap at 0. Sleep 1s
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-Avg 
-
-At capacity 65.24 %
-Below capacity 9.82 %
-Above capacity 24.94 %  
-----
-
-
-Combined Results.
-WorstAboveCap 
-Constant cap at 2. Sleep 1s
-At capacity 61.54 %
-Below capacity 7.69 %
-Above capacity 30.77 %  
-----
-
-WorstNotAtCap 
-Constant cap at 2. Sleep 1.1s
-At capacity 58.82 %
-Below capacity 11.76 %
-Above capacity 29.41 %  
-----
-
-Avg 
-
-At capacity 83.32 %
-Below capacity 4.82 %
-Above capacity 11.86 %  
-----
-
---- PASS: TestResizablePoolConcurrency (667.92s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.64s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.41s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.62s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.12s)
+--- PASS: TestResizablePoolConcurrency (669.30s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (37.08s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.51s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.58s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.07s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.06s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.05s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.75s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.08s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.62s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.08s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.75s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.66s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.78s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.18s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.71s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.18s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.14s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.18s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.81s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.25s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.81s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.11s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.75s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.09s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.67s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.05s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.68s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.10s)
 PASS
-ok  	github.com/RichardKnop/machinery/v1/common	1335.753s
+ok  	github.com/RichardKnop/machinery/v1/common	1337.950s

--- a/test_results
+++ b/test_results
@@ -2,17 +2,17 @@
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
 
 
-At capacity 97.30 %
-Below capacity 1.35 %
-Above capacity 1.35 %  
+At capacity 96.71 %
+Below capacity 1.97 %
+Above capacity 1.32 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
 
 
-At capacity 97.86 %
-Below capacity 0.71 %
-Above capacity 1.43 %  
+At capacity 98.53 %
+Below capacity 1.47 %
+Above capacity 0.00 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
@@ -26,25 +26,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
 
 
-At capacity 85.39 %
-Below capacity 7.87 %
-Above capacity 6.74 %  
+At capacity 95.56 %
+Below capacity 3.33 %
+Above capacity 1.11 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
 
 
-At capacity 65.71 %
-Below capacity 20.00 %
-Above capacity 14.29 %  
+At capacity 63.38 %
+Below capacity 32.39 %
+Above capacity 4.23 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
 
 
-At capacity 85.29 %
-Below capacity 8.82 %
-Above capacity 5.88 %  
+At capacity 74.65 %
+Below capacity 16.90 %
+Above capacity 8.45 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
@@ -58,294 +58,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
 
 
-At capacity 88.89 %
-Below capacity 4.94 %
-Above capacity 6.17 %  
+At capacity 91.67 %
+Below capacity 5.95 %
+Above capacity 2.38 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
 
 
-At capacity 93.83 %
-Below capacity 3.70 %
-Above capacity 2.47 %  
+At capacity 92.77 %
+Below capacity 1.20 %
+Above capacity 6.02 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
 
 
-At capacity 98.75 %
-Below capacity 0.00 %
-Above capacity 1.25 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
-
-
-At capacity 77.42 %
-Below capacity 11.29 %
-Above capacity 11.29 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
-
-
-At capacity 75.00 %
-Below capacity 20.00 %
-Above capacity 5.00 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
-
-
-At capacity 75.41 %
-Below capacity 13.11 %
-Above capacity 11.48 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
-
-
-At capacity 71.43 %
-Below capacity 17.46 %
-Above capacity 11.11 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
-
-
-At capacity 83.61 %
-Below capacity 14.75 %
-Above capacity 1.64 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
-
-
-At capacity 73.44 %
-Below capacity 15.62 %
-Above capacity 10.94 %  
-----
-
-
-Rolling Results.
-WorstAboveCap 
-rolling. Sleep 1s
-At capacity 65.71 %
-Below capacity 20.00 %
-Above capacity 14.29 %  
-----
-
-WorstNotAtCap 
-rolling. Sleep 1s
-At capacity 65.71 %
-Below capacity 20.00 %
-Above capacity 14.29 %  
-----
-
-Avg 
-
-At capacity 92.61 %
-Below capacity 3.96 %
-Above capacity 3.43 %  
-----
-
-
-Constant Results.
-WorstAboveCap 
-Constant cap at 0. Sleep 1s
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-WorstNotAtCap 
-Constant cap at 0. Sleep 1s
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-Avg 
-
-At capacity 76.01 %
-Below capacity 15.36 %
-Above capacity 8.63 %  
-----
-
-
-Combined Results.
-WorstAboveCap 
-rolling. Sleep 1s
-At capacity 65.71 %
-Below capacity 20.00 %
-Above capacity 14.29 %  
-----
-
-WorstNotAtCap 
-rolling. Sleep 1s
-At capacity 65.71 %
-Below capacity 20.00 %
-Above capacity 14.29 %  
-----
-
-Avg 
-
-At capacity 87.89 %
-Below capacity 7.20 %
-Above capacity 4.90 %  
-----
-
---- PASS: TestResizablePoolConcurrency (668.17s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.95s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.44s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.56s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.09s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.06s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.74s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.07s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.60s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.08s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.07s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.09s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.77s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.11s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.67s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.12s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.77s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.07s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.66s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.07s)
-=== RUN   TestResizablePoolConcurrency
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
-
-
-At capacity 96.03 %
-Below capacity 1.99 %
-Above capacity 1.99 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
-
-
-At capacity 97.86 %
-Below capacity 0.71 %
-Above capacity 1.43 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
-
-
-At capacity 100.00 %
-Below capacity 0.00 %
-Above capacity 0.00 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
-
-
-At capacity 85.23 %
-Below capacity 4.55 %
-Above capacity 10.23 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
-
-
-At capacity 62.86 %
-Below capacity 20.00 %
-Above capacity 17.14 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
-
-
-At capacity 81.94 %
-Below capacity 8.33 %
-Above capacity 9.72 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
-
-
-At capacity 100.00 %
-Below capacity 0.00 %
-Above capacity 0.00 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
-
-
-At capacity 84.34 %
-Below capacity 8.43 %
-Above capacity 7.23 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
-
-
-At capacity 93.83 %
-Below capacity 0.00 %
-Above capacity 6.17 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
-
-
-At capacity 96.25 %
+At capacity 97.50 %
 Below capacity 2.50 %
-Above capacity 1.25 %  
+Above capacity 0.00 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
@@ -399,72 +130,72 @@ Above capacity NaN %
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
 
 
-At capacity 74.19 %
-Below capacity 19.35 %
-Above capacity 6.45 %  
+At capacity 78.69 %
+Below capacity 19.67 %
+Above capacity 1.64 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
 
 
 At capacity 81.67 %
-Below capacity 10.00 %
-Above capacity 8.33 %  
+Below capacity 15.00 %
+Above capacity 3.33 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
 
 
-At capacity 78.69 %
-Below capacity 14.75 %
-Above capacity 6.56 %  
+At capacity 70.00 %
+Below capacity 26.67 %
+Above capacity 3.33 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
 
 
-At capacity 79.03 %
-Below capacity 17.74 %
-Above capacity 3.23 %  
+At capacity 74.19 %
+Below capacity 24.19 %
+Above capacity 1.61 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
 
 
-At capacity 77.05 %
-Below capacity 21.31 %
-Above capacity 1.64 %  
+At capacity 68.33 %
+Below capacity 25.00 %
+Above capacity 6.67 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
 
 
-At capacity 73.85 %
-Below capacity 7.69 %
-Above capacity 18.46 %  
+At capacity 72.58 %
+Below capacity 27.42 %
+Above capacity 0.00 %  
 ----
 
 
 Rolling Results.
 WorstAboveCap 
-rolling. Sleep 1s
-At capacity 62.86 %
-Below capacity 20.00 %
-Above capacity 17.14 %  
+rolling. Sleep 1.001s
+At capacity 74.65 %
+Below capacity 16.90 %
+Above capacity 8.45 %  
 ----
 
 WorstNotAtCap 
 rolling. Sleep 1s
-At capacity 62.86 %
-Below capacity 20.00 %
-Above capacity 17.14 %  
+At capacity 63.38 %
+Below capacity 32.39 %
+Above capacity 4.23 %  
 ----
 
 Avg 
 
-At capacity 91.30 %
-Below capacity 3.93 %
-Above capacity 4.78 %  
+At capacity 92.58 %
+Below capacity 5.40 %
+Above capacity 2.01 %  
 ----
 
 
@@ -485,56 +216,325 @@ Above capacity NaN %
 
 Avg 
 
-At capacity 77.36 %
-Below capacity 15.09 %
-Above capacity 7.55 %  
+At capacity 74.25 %
+Below capacity 23.01 %
+Above capacity 2.74 %  
 ----
 
 
 Combined Results.
 WorstAboveCap 
-Constant cap at 2. Sleep 600ms
-At capacity 73.85 %
-Below capacity 7.69 %
-Above capacity 18.46 %  
+rolling. Sleep 1.001s
+At capacity 74.65 %
+Below capacity 16.90 %
+Above capacity 8.45 %  
 ----
 
 WorstNotAtCap 
 rolling. Sleep 1s
-At capacity 62.86 %
-Below capacity 20.00 %
-Above capacity 17.14 %  
+At capacity 63.38 %
+Below capacity 32.39 %
+Above capacity 4.23 %  
 ----
 
 Avg 
 
-At capacity 87.36 %
-Below capacity 7.08 %
-Above capacity 5.56 %  
+At capacity 87.47 %
+Below capacity 10.31 %
+Above capacity 2.22 %  
 ----
 
---- PASS: TestResizablePoolConcurrency (669.30s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (37.08s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.51s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.58s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.07s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.05s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.78s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.18s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.71s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.18s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.14s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.18s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.81s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.25s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.81s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.11s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.05s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.77s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.12s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.68s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.10s)
+--- PASS: TestResizablePoolConcurrency (668.81s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (37.74s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.11s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.63s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.05s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.06s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.75s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.09s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.61s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.07s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.15s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.68s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.05s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.07s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.75s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.69s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.08s)
+=== RUN   TestResizablePoolConcurrency
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
+
+
+At capacity 97.73 %
+Below capacity 1.14 %
+Above capacity 1.14 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
+
+
+At capacity 69.74 %
+Below capacity 28.95 %
+Above capacity 1.32 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
+
+
+At capacity 82.09 %
+Below capacity 16.42 %
+Above capacity 1.49 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
+
+
+At capacity 88.61 %
+Below capacity 6.33 %
+Above capacity 5.06 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
+
+
+At capacity 82.93 %
+Below capacity 13.41 %
+Above capacity 3.66 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
+
+
+At capacity 98.75 %
+Below capacity 1.25 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
+
+
+At capacity 67.74 %
+Below capacity 27.42 %
+Above capacity 4.84 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
+
+
+At capacity 71.67 %
+Below capacity 20.00 %
+Above capacity 8.33 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
+
+
+At capacity 76.67 %
+Below capacity 23.33 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
+
+
+At capacity 79.03 %
+Below capacity 19.35 %
+Above capacity 1.61 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
+
+
+At capacity 81.67 %
+Below capacity 16.67 %
+Above capacity 1.67 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
+
+
+At capacity 80.65 %
+Below capacity 19.35 %
+Above capacity 0.00 %  
+----
+
+
+Rolling Results.
+WorstAboveCap 
+rolling. Sleep 500ms
+At capacity 88.61 %
+Below capacity 6.33 %
+Above capacity 5.06 %  
+----
+
+WorstNotAtCap 
+rolling. Sleep 1s
+At capacity 69.74 %
+Below capacity 28.95 %
+Above capacity 1.32 %  
+----
+
+Avg 
+
+At capacity 93.49 %
+Below capacity 5.44 %
+Above capacity 1.07 %  
+----
+
+
+Constant Results.
+WorstAboveCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+WorstNotAtCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+Avg 
+
+At capacity 76.23 %
+Below capacity 21.04 %
+Above capacity 2.73 %  
+----
+
+
+Combined Results.
+WorstAboveCap 
+Constant cap at 2. Sleep 1.001s
+At capacity 71.67 %
+Below capacity 20.00 %
+Above capacity 8.33 %  
+----
+
+WorstNotAtCap 
+Constant cap at 2. Sleep 1s
+At capacity 67.74 %
+Below capacity 27.42 %
+Above capacity 4.84 %  
+----
+
+Avg 
+
+At capacity 88.64 %
+Below capacity 9.82 %
+Above capacity 1.53 %  
+----
+
+--- PASS: TestResizablePoolConcurrency (670.74s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.47s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.32s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (31.11s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.21s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.14s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.15s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.83s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.21s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.77s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.37s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.23s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.23s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.85s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.32s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.87s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.21s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.16s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.15s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.82s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.24s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.84s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.23s)
 PASS
-ok  	github.com/RichardKnop/machinery/v1/common	1337.950s
+ok  	github.com/RichardKnop/machinery/v1/common	1340.242s

--- a/test_results
+++ b/test_results
@@ -2,17 +2,17 @@
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
 
 
-At capacity 97.32 %
-Below capacity 0.67 %
-Above capacity 2.01 %  
+At capacity 98.65 %
+Below capacity 0.00 %
+Above capacity 1.35 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
 
 
-At capacity 99.26 %
-Below capacity 0.74 %
-Above capacity 0.00 %  
+At capacity 95.59 %
+Below capacity 1.47 %
+Above capacity 2.94 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
@@ -26,25 +26,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
 
 
-At capacity 68.69 %
-Below capacity 5.05 %
-Above capacity 26.26 %  
+At capacity 85.71 %
+Below capacity 4.40 %
+Above capacity 9.89 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
 
 
-At capacity 42.27 %
-Below capacity 4.12 %
-Above capacity 53.61 %  
+At capacity 59.46 %
+Below capacity 16.22 %
+Above capacity 24.32 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
 
 
-At capacity 51.69 %
-Below capacity 3.37 %
-Above capacity 44.94 %  
+At capacity 73.97 %
+Below capacity 12.33 %
+Above capacity 13.70 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
@@ -57,295 +57,26 @@ Above capacity 0.00 %
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
 
-
-At capacity 71.26 %
-Below capacity 5.75 %
-Above capacity 22.99 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
-
-
-At capacity 89.41 %
-Below capacity 1.18 %
-Above capacity 9.41 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
-
-
-At capacity 87.95 %
-Below capacity 2.41 %
-Above capacity 9.64 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms
-
-
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
-
-
-At capacity 35.96 %
-Below capacity 4.49 %
-Above capacity 59.55 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
-
-
-At capacity 38.10 %
-Below capacity 8.33 %
-Above capacity 53.57 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
-
-
-At capacity 39.51 %
-Below capacity 11.11 %
-Above capacity 49.38 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
-
-
-At capacity 45.57 %
-Below capacity 7.59 %
-Above capacity 46.84 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
-
-
-At capacity 39.51 %
-Below capacity 11.11 %
-Above capacity 49.38 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
-
-
-At capacity 44.05 %
-Below capacity 7.14 %
-Above capacity 48.81 %  
-----
-
-
-Rolling Results.
-WorstAboveCap 
-rolling. Sleep 1s
-At capacity 42.27 %
-Below capacity 4.12 %
-Above capacity 53.61 %  
-----
-
-WorstNotAtCap 
-rolling. Sleep 1s
-At capacity 42.27 %
-Below capacity 4.12 %
-Above capacity 53.61 %  
-----
-
-Avg 
 
 At capacity 82.14 %
-Below capacity 2.20 %
-Above capacity 15.67 %  
-----
-
-
-Constant Results.
-WorstAboveCap 
-Constant cap at 0. Sleep 1s
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-WorstNotAtCap 
-Constant cap at 0. Sleep 1s
-At capacity NaN %
-Below capacity NaN %
-Above capacity NaN %  
-----
-
-Avg 
-
-At capacity 40.36 %
-Below capacity 8.23 %
-Above capacity 51.41 %  
-----
-
-
-Combined Results.
-WorstAboveCap 
-Constant cap at 2. Sleep 1s
-At capacity 35.96 %
-Below capacity 4.49 %
-Above capacity 59.55 %  
-----
-
-WorstNotAtCap 
-Constant cap at 2. Sleep 1s
-At capacity 35.96 %
-Below capacity 4.49 %
-Above capacity 59.55 %  
-----
-
-Avg 
-
-At capacity 68.27 %
-Below capacity 4.20 %
-Above capacity 27.53 %  
-----
-
---- PASS: TestResizablePoolConcurrency (667.53s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.33s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.95s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.77s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.12s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.08s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.05s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.77s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.08s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.60s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.11s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.05s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.77s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.14s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.70s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.11s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.75s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.11s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.68s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.13s)
-=== RUN   TestResizablePoolConcurrency
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
-
-
-At capacity 95.95 %
-Below capacity 1.35 %
-Above capacity 2.70 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
-
-
-At capacity 99.26 %
-Below capacity 0.00 %
-Above capacity 0.74 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
-
-
-At capacity 100.00 %
-Below capacity 0.00 %
-Above capacity 0.00 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
-
-
-At capacity 82.61 %
-Below capacity 3.26 %
-Above capacity 14.13 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
-
-
-At capacity 38.46 %
-Below capacity 4.81 %
-Above capacity 56.73 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
-
-
-At capacity 43.53 %
-Below capacity 12.94 %
-Above capacity 43.53 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
-
-
-At capacity 100.00 %
-Below capacity 0.00 %
-Above capacity 0.00 %  
-----
-
-=== RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
-
-
-At capacity 76.40 %
-Below capacity 1.12 %
-Above capacity 22.47 %  
+Below capacity 5.95 %
+Above capacity 11.90 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
 
 
-At capacity 90.00 %
-Below capacity 2.50 %
-Above capacity 7.50 %  
+At capacity 88.10 %
+Below capacity 1.19 %
+Above capacity 10.71 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
 
 
 At capacity 91.57 %
-Below capacity 0.00 %
-Above capacity 8.43 %  
+Below capacity 2.41 %
+Above capacity 6.02 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
@@ -399,72 +130,72 @@ Above capacity NaN %
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
 
 
-At capacity 40.45 %
-Below capacity 4.49 %
-Above capacity 55.06 %  
+At capacity 70.31 %
+Below capacity 9.38 %
+Above capacity 20.31 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
 
 
-At capacity 45.00 %
-Below capacity 2.50 %
-Above capacity 52.50 %  
+At capacity 66.13 %
+Below capacity 12.90 %
+Above capacity 20.97 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
 
 
-At capacity 39.02 %
-Below capacity 9.76 %
-Above capacity 51.22 %  
+At capacity 52.11 %
+Below capacity 8.45 %
+Above capacity 39.44 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
 
 
-At capacity 39.51 %
-Below capacity 8.64 %
-Above capacity 51.85 %  
+At capacity 59.70 %
+Below capacity 14.93 %
+Above capacity 25.37 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
 
 
-At capacity 58.67 %
-Below capacity 6.67 %
-Above capacity 34.67 %  
+At capacity 75.00 %
+Below capacity 14.06 %
+Above capacity 10.94 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
 
 
-At capacity 50.63 %
-Below capacity 7.59 %
-Above capacity 41.77 %  
+At capacity 72.31 %
+Below capacity 9.23 %
+Above capacity 18.46 %  
 ----
 
 
 Rolling Results.
 WorstAboveCap 
 rolling. Sleep 1s
-At capacity 38.46 %
-Below capacity 4.81 %
-Above capacity 56.73 %  
+At capacity 59.46 %
+Below capacity 16.22 %
+Above capacity 24.32 %  
 ----
 
 WorstNotAtCap 
 rolling. Sleep 1s
-At capacity 38.46 %
-Below capacity 4.81 %
-Above capacity 56.73 %  
+At capacity 59.46 %
+Below capacity 16.22 %
+Above capacity 24.32 %  
 ----
 
 Avg 
 
-At capacity 82.80 %
-Below capacity 2.41 %
-Above capacity 14.79 %  
+At capacity 89.26 %
+Below capacity 3.68 %
+Above capacity 7.05 %  
 ----
 
 
@@ -485,56 +216,325 @@ Above capacity NaN %
 
 Avg 
 
-At capacity 45.27 %
-Below capacity 6.58 %
-Above capacity 48.15 %  
+At capacity 65.65 %
+Below capacity 11.45 %
+Above capacity 22.90 %  
 ----
 
 
 Combined Results.
 WorstAboveCap 
-rolling. Sleep 1s
-At capacity 38.46 %
-Below capacity 4.81 %
-Above capacity 56.73 %  
+Constant cap at 2. Sleep 1.1s
+At capacity 52.11 %
+Below capacity 8.45 %
+Above capacity 39.44 %  
 ----
 
 WorstNotAtCap 
-rolling. Sleep 1s
-At capacity 38.46 %
-Below capacity 4.81 %
-Above capacity 56.73 %  
+Constant cap at 2. Sleep 1.1s
+At capacity 52.11 %
+Below capacity 8.45 %
+Above capacity 39.44 %  
 ----
 
 Avg 
 
-At capacity 70.47 %
-Below capacity 3.78 %
-Above capacity 25.74 %  
+At capacity 82.35 %
+Below capacity 5.96 %
+Above capacity 11.69 %  
 ----
 
---- PASS: TestResizablePoolConcurrency (666.97s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.06s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.77s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.71s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.10s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.05s)
+--- PASS: TestResizablePoolConcurrency (667.32s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.19s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.05s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.70s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.13s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.06s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.07s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.75s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.09s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.61s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.62s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.09s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.05s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.07s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.11s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.75s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.08s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.77s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.15s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.70s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.11s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.05s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.07s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.77s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.66s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.07s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.68s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.09s)
+=== RUN   TestResizablePoolConcurrency
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
+
+
+At capacity 97.86 %
+Below capacity 0.00 %
+Above capacity 2.14 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
+
+
+At capacity 81.11 %
+Below capacity 4.44 %
+Above capacity 14.44 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
+
+
+At capacity 72.22 %
+Below capacity 13.89 %
+Above capacity 13.89 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
+
+
+At capacity 79.49 %
+Below capacity 5.13 %
+Above capacity 15.38 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
+
+
+At capacity 100.00 %
+Below capacity 0.00 %
+Above capacity 0.00 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
+
+
+At capacity 78.05 %
+Below capacity 3.66 %
+Above capacity 18.29 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
+
+
+At capacity 91.57 %
+Below capacity 2.41 %
+Above capacity 6.02 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
+
+
+At capacity 92.68 %
+Below capacity 3.66 %
+Above capacity 3.66 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms
+
+
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
+
+
+At capacity 61.54 %
+Below capacity 7.69 %
+Above capacity 30.77 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
+
+
+At capacity 66.67 %
+Below capacity 11.11 %
+Above capacity 22.22 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
+
+
+At capacity 58.82 %
+Below capacity 11.76 %
+Above capacity 29.41 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
+
+
+At capacity 64.71 %
+Below capacity 8.82 %
+Above capacity 26.47 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
+
+
+At capacity 63.24 %
+Below capacity 10.29 %
+Above capacity 26.47 %  
+----
+
+=== RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
+
+
+At capacity 76.92 %
+Below capacity 9.23 %
+Above capacity 13.85 %  
+----
+
+
+Rolling Results.
+WorstAboveCap 
+rolling. Sleep 500ms
+At capacity 78.05 %
+Below capacity 3.66 %
+Above capacity 18.29 %  
+----
+
+WorstNotAtCap 
+rolling. Sleep 1s
+At capacity 72.22 %
+Below capacity 13.89 %
+Above capacity 13.89 %  
+----
+
+Avg 
+
+At capacity 90.86 %
+Below capacity 2.73 %
+Above capacity 6.41 %  
+----
+
+
+Constant Results.
+WorstAboveCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+WorstNotAtCap 
+Constant cap at 0. Sleep 1s
+At capacity NaN %
+Below capacity NaN %
+Above capacity NaN %  
+----
+
+Avg 
+
+At capacity 65.24 %
+Below capacity 9.82 %
+Above capacity 24.94 %  
+----
+
+
+Combined Results.
+WorstAboveCap 
+Constant cap at 2. Sleep 1s
+At capacity 61.54 %
+Below capacity 7.69 %
+Above capacity 30.77 %  
+----
+
+WorstNotAtCap 
+Constant cap at 2. Sleep 1.1s
+At capacity 58.82 %
+Below capacity 11.76 %
+Above capacity 29.41 %  
+----
+
+Avg 
+
+At capacity 83.32 %
+Below capacity 4.82 %
+Above capacity 11.86 %  
+----
+
+--- PASS: TestResizablePoolConcurrency (667.92s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (36.64s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (34.41s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.62s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.06s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.05s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.75s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.08s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.62s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.06s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.75s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.66s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.10s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.06s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.75s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.67s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.09s)
 PASS
-ok  	github.com/RichardKnop/machinery/v1/common	1335.091s
+ok  	github.com/RichardKnop/machinery/v1/common	1335.753s

--- a/test_results
+++ b/test_results
@@ -2,17 +2,17 @@
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
 
 
-At capacity 98.57 %
-Below capacity 0.71 %
-Above capacity 0.71 %  
+At capacity 97.92 %
+Below capacity 0.69 %
+Above capacity 1.39 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
 
 
-At capacity 99.24 %
+At capacity 100.00 %
 Below capacity 0.00 %
-Above capacity 0.76 %  
+Above capacity 0.00 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_77ms
@@ -26,25 +26,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
 
 
-At capacity 57.58 %
-Below capacity 1.01 %
-Above capacity 41.41 %  
+At capacity 59.79 %
+Below capacity 3.09 %
+Above capacity 37.11 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
 
 
-At capacity 31.90 %
-Below capacity 2.59 %
-Above capacity 65.52 %  
+At capacity 36.46 %
+Below capacity 1.04 %
+Above capacity 62.50 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
 
 
-At capacity 32.35 %
-Below capacity 0.98 %
-Above capacity 66.67 %  
+At capacity 60.92 %
+Below capacity 6.90 %
+Above capacity 32.18 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
@@ -58,25 +58,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
 
 
-At capacity 64.84 %
-Below capacity 1.10 %
-Above capacity 34.07 %  
+At capacity 68.18 %
+Below capacity 4.55 %
+Above capacity 27.27 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
 
 
-At capacity 90.24 %
-Below capacity 1.22 %
-Above capacity 8.54 %  
+At capacity 82.14 %
+Below capacity 2.38 %
+Above capacity 15.48 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
 
 
-At capacity 97.53 %
-Below capacity 0.00 %
-Above capacity 2.47 %  
+At capacity 80.90 %
+Below capacity 1.12 %
+Above capacity 17.98 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
@@ -130,9 +130,9 @@ Above capacity NaN %
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
 
 
-At capacity 43.21 %
-Below capacity 0.00 %
-Above capacity 56.79 %  
+At capacity 34.52 %
+Below capacity 2.38 %
+Above capacity 63.10 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
@@ -146,56 +146,56 @@ Above capacity 55.84 %
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
 
 
-At capacity 36.25 %
-Below capacity 1.25 %
-Above capacity 62.50 %  
+At capacity 30.59 %
+Below capacity 3.53 %
+Above capacity 65.88 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
 
 
-At capacity 34.15 %
-Below capacity 1.22 %
-Above capacity 64.63 %  
+At capacity 45.00 %
+Below capacity 5.00 %
+Above capacity 50.00 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
 
 
-At capacity 40.51 %
-Below capacity 0.00 %
-Above capacity 59.49 %  
+At capacity 35.00 %
+Below capacity 2.50 %
+Above capacity 62.50 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
 
 
-At capacity 24.14 %
-Below capacity 1.15 %
-Above capacity 74.71 %  
+At capacity 46.25 %
+Below capacity 3.75 %
+Above capacity 50.00 %  
 ----
 
 
 Rolling Results.
 WorstAboveCap 
-rolling. Sleep 1.001s
-At capacity 32.35 %
-Below capacity 0.98 %
-Above capacity 66.67 %  
+rolling. Sleep 1s
+At capacity 36.46 %
+Below capacity 1.04 %
+Above capacity 62.50 %  
 ----
 
 WorstNotAtCap 
 rolling. Sleep 1s
-At capacity 31.90 %
-Below capacity 2.59 %
-Above capacity 65.52 %  
+At capacity 36.46 %
+Below capacity 1.04 %
+Above capacity 62.50 %  
 ----
 
 Avg 
 
-At capacity 76.96 %
-Below capacity 0.78 %
-Above capacity 22.25 %  
+At capacity 80.26 %
+Below capacity 1.80 %
+Above capacity 17.94 %  
 ----
 
 
@@ -216,71 +216,71 @@ Above capacity NaN %
 
 Avg 
 
-At capacity 36.21 %
-Below capacity 1.23 %
-Above capacity 62.55 %  
+At capacity 38.48 %
+Below capacity 3.50 %
+Above capacity 58.02 %  
 ----
 
 
 Combined Results.
 WorstAboveCap 
-Constant cap at 2. Sleep 600ms
-At capacity 24.14 %
-Below capacity 1.15 %
-Above capacity 74.71 %  
+Constant cap at 2. Sleep 1.1s
+At capacity 30.59 %
+Below capacity 3.53 %
+Above capacity 65.88 %  
 ----
 
 WorstNotAtCap 
-Constant cap at 2. Sleep 600ms
-At capacity 24.14 %
-Below capacity 1.15 %
-Above capacity 74.71 %  
+Constant cap at 2. Sleep 1.1s
+At capacity 30.59 %
+Below capacity 3.53 %
+Above capacity 65.88 %  
 ----
 
 Avg 
 
-At capacity 63.81 %
-Below capacity 0.93 %
-Above capacity 35.26 %  
+At capacity 66.58 %
+Below capacity 2.36 %
+Above capacity 31.06 %  
 ----
 
---- PASS: TestResizablePoolConcurrency (665.56s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (34.88s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.01s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (31.01s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.13s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.09s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.08s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.80s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.08s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.61s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.10s)
+--- PASS: TestResizablePoolConcurrency (666.64s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (35.89s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.54s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.78s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.11s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.07s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.07s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.76s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.07s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.62s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.09s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.08s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.78s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.14s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.71s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.13s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.08s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.09s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.77s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.11s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.67s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.76s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.13s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.68s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.06s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.76s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.68s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.10s)
 === RUN   TestResizablePoolConcurrency
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1ms
 
 
-At capacity 95.17 %
-Below capacity 0.00 %
-Above capacity 4.83 %  
+At capacity 98.61 %
+Below capacity 0.69 %
+Above capacity 0.69 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_3ms
 
 
-At capacity 97.79 %
-Below capacity 0.74 %
+At capacity 98.53 %
+Below capacity 0.00 %
 Above capacity 1.47 %  
 ----
 
@@ -295,25 +295,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_333ms
 
 
-At capacity 65.62 %
-Below capacity 0.00 %
-Above capacity 34.38 %  
+At capacity 77.78 %
+Below capacity 2.02 %
+Above capacity 20.20 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1s
 
 
-At capacity 40.21 %
-Below capacity 2.06 %
-Above capacity 57.73 %  
+At capacity 47.92 %
+Below capacity 2.08 %
+Above capacity 50.00 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.001s
 
 
-At capacity 46.24 %
-Below capacity 1.08 %
-Above capacity 52.69 %  
+At capacity 27.17 %
+Below capacity 1.09 %
+Above capacity 71.74 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_1.1s
@@ -327,25 +327,25 @@ Above capacity 0.00 %
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_500ms
 
 
-At capacity 63.22 %
-Below capacity 4.60 %
-Above capacity 32.18 %  
+At capacity 75.28 %
+Below capacity 1.12 %
+Above capacity 23.60 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_501ms
 
 
-At capacity 86.59 %
-Below capacity 1.22 %
-Above capacity 12.20 %  
+At capacity 86.90 %
+Below capacity 0.00 %
+Above capacity 13.10 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/rolling._Sleep_600ms
 
 
-At capacity 83.72 %
+At capacity 87.06 %
 Below capacity 0.00 %
-Above capacity 16.28 %  
+Above capacity 12.94 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s
@@ -399,72 +399,72 @@ Above capacity NaN %
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s
 
 
-At capacity 39.02 %
+At capacity 28.72 %
 Below capacity 0.00 %
-Above capacity 60.98 %  
+Above capacity 71.28 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s
 
 
-At capacity 32.53 %
-Below capacity 2.41 %
-Above capacity 65.06 %  
+At capacity 37.33 %
+Below capacity 5.33 %
+Above capacity 57.33 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s
 
 
-At capacity 45.57 %
-Below capacity 2.53 %
-Above capacity 51.90 %  
+At capacity 40.00 %
+Below capacity 0.00 %
+Above capacity 60.00 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms
 
 
-At capacity 30.49 %
-Below capacity 1.22 %
-Above capacity 68.29 %  
+At capacity 45.12 %
+Below capacity 2.44 %
+Above capacity 52.44 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms
 
 
-At capacity 36.90 %
+At capacity 32.14 %
 Below capacity 0.00 %
-Above capacity 63.10 %  
+Above capacity 67.86 %  
 ----
 
 === RUN   TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms
 
 
-At capacity 35.37 %
-Below capacity 0.00 %
-Above capacity 64.63 %  
+At capacity 43.37 %
+Below capacity 2.41 %
+Above capacity 54.22 %  
 ----
 
 
 Rolling Results.
 WorstAboveCap 
-rolling. Sleep 1s
-At capacity 40.21 %
-Below capacity 2.06 %
-Above capacity 57.73 %  
+rolling. Sleep 1.001s
+At capacity 27.17 %
+Below capacity 1.09 %
+Above capacity 71.74 %  
 ----
 
 WorstNotAtCap 
-rolling. Sleep 1s
-At capacity 40.21 %
-Below capacity 2.06 %
-Above capacity 57.73 %  
+rolling. Sleep 1.001s
+At capacity 27.17 %
+Below capacity 1.09 %
+Above capacity 71.74 %  
 ----
 
 Avg 
 
-At capacity 79.18 %
-Below capacity 0.90 %
-Above capacity 19.92 %  
+At capacity 81.34 %
+Below capacity 0.70 %
+Above capacity 17.96 %  
 ----
 
 
@@ -485,56 +485,56 @@ Above capacity NaN %
 
 Avg 
 
-At capacity 36.59 %
-Below capacity 1.02 %
-Above capacity 62.40 %  
+At capacity 37.55 %
+Below capacity 1.61 %
+Above capacity 60.84 %  
 ----
 
 
 Combined Results.
 WorstAboveCap 
-Constant cap at 2. Sleep 500ms
-At capacity 30.49 %
-Below capacity 1.22 %
-Above capacity 68.29 %  
+rolling. Sleep 1.001s
+At capacity 27.17 %
+Below capacity 1.09 %
+Above capacity 71.74 %  
 ----
 
 WorstNotAtCap 
-Constant cap at 2. Sleep 500ms
-At capacity 30.49 %
-Below capacity 1.22 %
-Above capacity 68.29 %  
+rolling. Sleep 1.001s
+At capacity 27.17 %
+Below capacity 1.09 %
+Above capacity 71.74 %  
 ----
 
 Avg 
 
-At capacity 65.12 %
-Below capacity 0.94 %
-Above capacity 33.94 %  
+At capacity 66.80 %
+Below capacity 1.00 %
+Above capacity 32.20 %  
 ----
 
---- PASS: TestResizablePoolConcurrency (666.12s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (35.56s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.26s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.85s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.11s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.06s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.08s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.74s)
-    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.11s)
+--- PASS: TestResizablePoolConcurrency (666.70s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1ms (35.94s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_3ms (33.45s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_77ms (30.74s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_333ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1s (30.08s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.001s (29.07s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_1.1s (29.77s)
+    --- PASS: TestResizablePoolConcurrency/rolling._Sleep_500ms (30.09s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_501ms (29.62s)
     --- PASS: TestResizablePoolConcurrency/rolling._Sleep_600ms (30.09s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.07s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.77s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.12s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.69s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1s (30.05s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.001s (29.11s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_1.1s (29.78s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_500ms (30.18s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_501ms (29.71s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_0._Sleep_600ms (30.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.08s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1s (30.07s)
     --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.001s (29.07s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.75s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.10s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.68s)
-    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.09s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_1.1s (29.76s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_500ms (30.12s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_501ms (29.69s)
+    --- PASS: TestResizablePoolConcurrency/Constant_cap_at_2._Sleep_600ms (30.11s)
 PASS
-ok  	github.com/RichardKnop/machinery/v1/common	1332.153s
+ok  	github.com/RichardKnop/machinery/v1/common	1333.836s

--- a/v1/brokers/iface/interfaces.go
+++ b/v1/brokers/iface/interfaces.go
@@ -26,7 +26,9 @@ type ResizeablePool interface {
 
 	Pool() <-chan struct{}
 
-	SetCapacity(int)
+	// SetCapacity Returns a channel which will receive a value when the change has been fully accepted. Most users should ignore
+	// this.
+	SetCapacity(int) <-chan struct{}
 }
 
 type RetrySameMessage interface {

--- a/v1/common/broker.go
+++ b/v1/common/broker.go
@@ -3,6 +3,7 @@ package common
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 
 	"github.com/RichardKnop/machinery/v1/brokers/iface"
 	"github.com/RichardKnop/machinery/v1/config"
@@ -163,8 +164,8 @@ func NewResizablePool(startingCapacity int) (iface.ResizeablePool, func()) {
 		// capacity available at one point that wasn't used isn't given when capacity is lowered.
 		lastGiverCancel chan struct{}
 
-		capacity int
-		taken    int
+		capacity int64
+		taken    int64
 
 		// Used to cancel the background routine/release resources
 		cancelChan = make(chan struct{}, 1)
@@ -191,12 +192,12 @@ func NewResizablePool(startingCapacity int) (iface.ResizeablePool, func()) {
 
 				// Calculate what's available based on the change
 				if c.isReturned {
-					taken--
+					atomic.AddInt64(&taken, -1)
 				}
 				if c.updatedCap != nil {
-					capacity = *c.updatedCap
+					capacity = int64(*c.updatedCap)
 				}
-				canGive := capacity - taken
+				canGive := capacity - atomic.LoadInt64(&taken)
 
 				if canGive > 0 {
 					// Launch a cancellable function which will populate the pool when there's a listener
@@ -205,12 +206,21 @@ func NewResizablePool(startingCapacity int) (iface.ResizeablePool, func()) {
 					lastGiverCancel = make(chan struct{}, 1)
 
 					go func() {
-						for i := 0; i < canGive; i++ {
+						for i := 0; i < int(canGive); i++ {
+							select {
+							case <-lastGiverCancel:
+								return
+							default:
+							}
+
+							// If both <-lastGiverCancel and rc.pool <- there will be a 50/50 chance of either
+							// occurring. The select above reduces the odds of this happening, but it is possible to
+							// give 1 when lastGiverCancel has an element if rc.pool is eligible at the "same" time.
 							select {
 							case <-lastGiverCancel:
 								return
 							case rc.pool <- struct{}{}:
-								taken++
+								atomic.AddInt64(&taken, 1)
 							}
 						}
 					}()

--- a/v1/common/broker_test.go
+++ b/v1/common/broker_test.go
@@ -1,6 +1,9 @@
 package common_test
 
 import (
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -187,4 +190,275 @@ func TestResizablePool(t *testing.T) {
 	acquireBlocksTillAdd()
 
 	cancel()
+}
+
+func TestResizablePoolConcurrency(t *testing.T) {
+	// TODO: Add a rolling down function
+	rollingCapFunc := func(changeItr int) int {
+		return changeItr % 5
+	}
+
+	desc := "rolling"
+
+	var rollingResults Results
+	launchTestResizablePoolConcurrency(t, desc, time.Millisecond, rollingCapFunc, &rollingResults)
+	launchTestResizablePoolConcurrency(t, desc, 3*time.Millisecond, rollingCapFunc, &rollingResults)
+	launchTestResizablePoolConcurrency(t, desc, 77*time.Millisecond, rollingCapFunc, &rollingResults)
+	launchTestResizablePoolConcurrency(t, desc, 333*time.Millisecond, rollingCapFunc, &rollingResults)
+	launchTestResizablePoolConcurrency(t, desc, time.Second, rollingCapFunc, &rollingResults)
+	launchTestResizablePoolConcurrency(t, desc, time.Second+time.Millisecond, rollingCapFunc, &rollingResults)
+	launchTestResizablePoolConcurrency(t, desc, time.Second+100*time.Millisecond, rollingCapFunc, &rollingResults)
+
+	launchTestResizablePoolConcurrency(t, desc, time.Second/2, rollingCapFunc, &rollingResults)
+	launchTestResizablePoolConcurrency(t, desc, time.Second/2+time.Millisecond, rollingCapFunc, &rollingResults)
+	launchTestResizablePoolConcurrency(t, desc, time.Second/2+100*time.Millisecond, rollingCapFunc, &rollingResults)
+
+	var constantResults Results
+
+	for i := 0; i < 2; i++ {
+		cap := i * 2
+		constantCapFunc := func(int) int {
+			return i * 2
+		}
+
+		desc = fmt.Sprintf("Constant cap at %d", cap)
+
+		launchTestResizablePoolConcurrency(t, desc, time.Second, constantCapFunc, &constantResults)
+		launchTestResizablePoolConcurrency(t, desc, time.Second+time.Millisecond, constantCapFunc, &constantResults)
+		launchTestResizablePoolConcurrency(t, desc, time.Second+100*time.Millisecond, constantCapFunc, &constantResults)
+
+		launchTestResizablePoolConcurrency(t, desc, time.Second/2, constantCapFunc, &constantResults)
+		launchTestResizablePoolConcurrency(t, desc, time.Second/2+time.Millisecond, constantCapFunc, &constantResults)
+		launchTestResizablePoolConcurrency(t, desc, time.Second/2+100*time.Millisecond, constantCapFunc, &constantResults)
+	}
+
+	fmt.Printf(`
+Rolling Results.
+WorstAboveCap %v
+WorstNotAtCap %v
+Avg %v
+`, rollingResults.WorstAboveCap(), rollingResults.WorstNotAtCap(), rollingResults.Average())
+
+	fmt.Printf(`
+Constant Results.
+WorstAboveCap %v
+WorstNotAtCap %v
+Avg %v
+`, constantResults.WorstAboveCap(), constantResults.WorstNotAtCap(), constantResults.Average())
+
+	combined := append(rollingResults, constantResults...)
+	fmt.Printf(`
+Combined Results.
+WorstAboveCap %v
+WorstNotAtCap %v
+Avg %v
+`, combined.WorstAboveCap(), combined.WorstNotAtCap(), combined.Average())
+}
+
+func launchTestResizablePoolConcurrency(
+	t *testing.T,
+	desc string,
+	capChangeSleep time.Duration,
+	capChangeFunc func(int) int,
+	resultCollection *Results) {
+	var resultChan = make(chan ResizablePoolConcurrencyResult, 1)
+
+	name := fmt.Sprintf("%s. Sleep %s", desc, capChangeSleep.String())
+	t.Run(name, func(t *testing.T) {
+		//t.Parallel()
+		resultChan <- testResizablePoolConcurrency(t, capChangeSleep, capChangeFunc)
+	})
+
+	result := <-resultChan
+	result.Meta = name
+	*resultCollection = append(*resultCollection, result)
+}
+
+func testResizablePoolConcurrency(t *testing.T, capChangeSleep time.Duration, capChangeFunc func(int) int) ResizablePoolConcurrencyResult {
+	consumerCount := 100
+
+	rs, cancel := common.NewResizablePool(0)
+
+	var consumerCancelChans []chan struct{}
+
+	var concurrency int64
+
+	type CapRecord struct {
+		Actual    int64
+		LastCap   int64
+		NewestCap int64
+	}
+
+	var desiredAndCapLock sync.Mutex
+	var capRecords []CapRecord
+	var lastCap, newestCap int64
+
+	for i := 0; i < consumerCount; i++ {
+		cc := make(chan struct{}, 1)
+		consumerCancelChans = append(consumerCancelChans, cc)
+
+		go func() {
+			p := rs.Pool()
+
+			for {
+				select {
+				case <-cc:
+					return
+				case <-p:
+				}
+
+				oldVal := atomic.AddInt64(&concurrency, 1)
+				require.GreaterOrEqual(t, oldVal, int64(0)) // Test problem if this fails
+
+				act := atomic.LoadInt64(&concurrency)
+				last := atomic.LoadInt64(&lastCap)
+				newest := atomic.LoadInt64(&newestCap)
+				desiredAndCapLock.Lock()
+				capRecords = append(capRecords, CapRecord{
+					Actual:    act,
+					LastCap:   last,
+					NewestCap: newest,
+				})
+				desiredAndCapLock.Unlock()
+
+				// TODO: variable timer + maybe variable delay on launch? The latter may cause below cap?
+
+				// "work"
+				select {
+				case <-cc:
+					return
+				case <-time.NewTimer(time.Second).C:
+				}
+
+				preReturn := time.Now()
+				rs.Return()
+				assert.Less(t, time.Since(preReturn), time.Millisecond)
+
+				atomic.AddInt64(&concurrency, -1)
+			}
+		}()
+	}
+
+	for i := 0; i < int(time.Second*30/capChangeSleep); i++ {
+		newCap := capChangeFunc(i)
+		atomic.StoreInt64(&newestCap, int64(newCap))
+
+		preSet := time.Now()
+		// Block on the capacity being set correctly before setting lastCap to the newCap. This ensures the test isn't
+		// racing against setting the capacity.
+		<-rs.SetCapacity(newCap)
+		assert.Less(t, time.Since(preSet), time.Millisecond)
+
+		// fmt.Printf("Setting capacity to %d. Iteration %d \n", newCap, i)
+
+		atomic.StoreInt64(&lastCap, int64(newCap))
+
+		time.Sleep(capChangeSleep)
+	}
+
+	// End of test cleanup
+	for _, cc := range consumerCancelChans {
+		cc <- struct{}{}
+	}
+	cancel()
+
+	var result ResizablePoolConcurrencyResult
+	for _, cr := range capRecords {
+		result.Total++
+
+		minCap := cr.LastCap
+		if cr.NewestCap < minCap {
+			minCap = cr.NewestCap
+		}
+		maxCap := cr.LastCap
+		if cr.NewestCap > maxCap {
+			maxCap = cr.NewestCap
+		}
+
+		if cr.Actual >= minCap && cr.Actual <= maxCap {
+			result.CountAtCap++
+		} else if cr.Actual < minCap {
+			result.CountBelowCap++
+		} else if cr.Actual > maxCap {
+			result.CountAboveCap++
+		}
+	}
+
+	fmt.Println(result.String())
+
+	return result
+}
+
+type ResizablePoolConcurrencyResult struct {
+	CountAtCap    float64
+	CountBelowCap float64
+	CountAboveCap float64
+	Total         float64
+
+	Meta string
+}
+
+type Results []ResizablePoolConcurrencyResult
+
+func (result ResizablePoolConcurrencyResult) String() string {
+	return fmt.Sprintf(`
+%s
+At capacity %.2f %%
+Below capacity %.2f %%
+Above capacity %.2f %%  
+----
+`,
+		result.Meta,
+		result.PerAt(),
+		100*result.CountBelowCap/result.Total,
+		result.PerAbove(),
+	)
+
+}
+
+func (result ResizablePoolConcurrencyResult) PerAbove() float64 {
+	return 100 * result.CountAboveCap / result.Total
+}
+
+func (result ResizablePoolConcurrencyResult) PerAt() float64 {
+	return 100 * result.CountAtCap / result.Total
+}
+
+func (results Results) WorstAboveCap() *ResizablePoolConcurrencyResult {
+	var worst *ResizablePoolConcurrencyResult
+
+	for _, r := range results {
+		if worst == nil || worst.PerAbove() < r.PerAbove() {
+			rCpy := r
+			worst = &rCpy
+		}
+	}
+
+	return worst
+}
+
+func (results Results) WorstNotAtCap() *ResizablePoolConcurrencyResult {
+	var worst *ResizablePoolConcurrencyResult
+
+	for _, r := range results {
+		if worst == nil || worst.PerAt() > r.PerAt() {
+			rCpy := r
+			worst = &rCpy
+		}
+	}
+
+	return worst
+}
+
+func (results Results) Average() ResizablePoolConcurrencyResult {
+	var avg ResizablePoolConcurrencyResult
+
+	for _, r := range results {
+		avg.CountAboveCap += r.CountAboveCap
+		avg.CountBelowCap += r.CountBelowCap
+		avg.CountAtCap += r.CountAtCap
+		avg.Total += r.Total
+	}
+
+	return avg
 }


### PR DESCRIPTION
The previous iteration relied on [this part](https://github.com/sublime-security/machinery/blob/master/v1/common/broker.go#L208) of the select statement being reliably hit whenever an item was on the `lastGiverCancel` channel. If `lastGiverCancel` channel has an item, but the go routine is still giving out capacity, then we're exceeding our desired concurrency. I, mistakenly, believed that select cases were ordered. [This article](https://medium.com/a-journey-with-go/go-ordering-in-select-statements-fd0ff80fd8d6) does a good job showing the actual behavior.

Also, given that this isn't true `taken` could have been modified concurrently (which was called out in [this comment](https://github.com/sublime-security/machinery/pull/15#discussion_r909664898) -- I was wrong, but thinking that it still wouldn't be concurrent because of the cancel channel).

----

Each commit includes `test_results`, `go test ./v1/common -timeout 30m -v -count 2 -run TestResizablePoolConcurrency > test_results`. This test attempts to evaluate how well the resizable pool works. It varies a lot based on the timing of changing the capacity relative to the worker times. The test probably isn't perfect but it shows improvements across my changes. 

Each test prints some some summaries, e.g. "Constant Results" "Avg" is the avg performance of all the tests that ran with a capacity that kept being reset to the same value (also the NaN results are fine -- they're from running with 0 capacity).

Looking at the constant size tests first, originally we exceeded our desired capacity ~63% of the time (on average). Each change improves this number slightly, but the last changes gets this down to ~3%.

With the rolling capacity test, originally we were at the correct capacity ~80% of the time (on average), but the worst test case was at capacity just 40% of the time. By the last commit, the average is up to 92% and the worst case is still at capacity 63% of the time. For the worst case, the improvement is better than just 40% -> 63%: originally 57% of the time we were above desired capacity, and in the last commit this is reduced to 9% in the worst case.
