### PR TITLE
Replace ETA with delay

### DIFF
--- a/integration-tests/suite_test.go
+++ b/integration-tests/suite_test.go
@@ -304,9 +304,9 @@ func testPanic(server Server, t *testing.T) {
 }
 
 func testDelay(server Server, t *testing.T) {
-	now := time.Now().UTC()
-	eta := now.Add(100 * time.Millisecond)
-	task := newDelayTask(eta)
+	delay := 100 * time.Millisecond
+	eta := time.Now().UTC().Add(delay)
+	task := newDelayTask(delay)
 	asyncResult, err := server.SendTask(task)
 	if err != nil {
 		t.Error(err)
@@ -480,9 +480,9 @@ func newMultipleReturnTask(arg1, arg2 string, fail bool) *tasks.Signature {
 	}
 }
 
-func newDelayTask(eta time.Time) *tasks.Signature {
+func newDelayTask(delay time.Duration) *tasks.Signature {
 	return &tasks.Signature{
-		Name: "delay_test",
-		ETA:  &eta,
+		Name:  "delay_test",
+		Delay: delay,
 	}
 }

--- a/v1/brokers/amqp/amqp.go
+++ b/v1/brokers/amqp/amqp.go
@@ -191,16 +191,10 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 		return fmt.Errorf("JSON marshal error: %s", err)
 	}
 
-	// Check the ETA signature field, if it is set and it is in the future,
+	// Check the delay signature field, if it is set and it is in the future,
 	// delay the task
-	if signature.ETA != nil {
-		now := time.Now().UTC()
-
-		if signature.ETA.After(now) {
-			delayMs := int64(signature.ETA.Sub(now) / time.Millisecond)
-
-			return b.delay(signature, delayMs)
-		}
+	if signature.Delay > 0 {
+		return b.delay(signature, signature.Delay.Milliseconds())
 	}
 
 	queue := b.GetConfig().DefaultQueue

--- a/v1/server.go
+++ b/v1/server.go
@@ -198,8 +198,8 @@ func (server *Server) SendTaskWithContext(ctx context.Context, signature *tasks.
 		signature.Headers = tracing.HeadersWithSpan(signature.Headers, span)
 	}
 
-	if signature.ETA != nil {
-		span.SetTag("signature.eta", signature.ETA.String())
+	if signature.Delay > 0 {
+		span.SetTag("signature.eta", signature.Delay.String())
 	}
 
 	// Make sure result backend is defined

--- a/v1/tasks/errors.go
+++ b/v1/tasks/errors.go
@@ -5,29 +5,8 @@ import (
 	"time"
 )
 
-// ErrRetryTaskLater ...
-type ErrRetryTaskLater struct {
-	name, msg string
-	retryIn   time.Duration
-}
-
-// RetryIn returns time.Duration from now when task should be retried
-func (e ErrRetryTaskLater) RetryIn() time.Duration {
-	return e.retryIn
-}
-
-// Error implements the error interface
-func (e ErrRetryTaskLater) Error() string {
-	return fmt.Sprintf("Task error: %s Will retry in: %s", e.msg, e.retryIn)
-}
-
-// NewErrRetryTaskLater returns new ErrRetryTaskLater instance
-func NewErrRetryTaskLater(msg string, retryIn time.Duration) ErrRetryTaskLater {
-	return ErrRetryTaskLater{msg: msg, retryIn: retryIn}
-}
-
-// Retriable is interface that retriable errors should implement
-type Retriable interface {
+// Retryable is interface that retryable errors should implement
+type Retryable interface {
 	RetryIn() time.Duration
 	error
 }

--- a/v1/tasks/signature.go
+++ b/v1/tasks/signature.go
@@ -48,7 +48,7 @@ type Signature struct {
 	UUID           string
 	Name           string
 	RoutingKey     string
-	ETA            *time.Time
+	Delay          time.Duration
 	IngestionTime  *time.Time
 	FirstReceived  *time.Time
 	ReceivedAt     time.Time

--- a/v1/tasks/task.go
+++ b/v1/tasks/task.go
@@ -124,9 +124,9 @@ func New(taskFunc interface{}, args []Arg) (*Task, error) {
 // Call attempts to call the task with the supplied arguments.
 //
 // `err` is set in the return value in two cases:
-// 1. The reflected function invocation panics (e.g. due to a mismatched
-//    argument list).
-// 2. The task func itself returns a non-nil error.
+//  1. The reflected function invocation panics (e.g. due to a mismatched
+//     argument list).
+//  2. The task func itself returns a non-nil error.
 func (t *Task) Call() (taskResults []*TaskResult, err error) {
 	// retrieve the span from the task's context and finish it as soon as this function returns
 	span := opentracing.SpanFromContext(t.Context)
@@ -202,16 +202,16 @@ func (t *Task) Call() (taskResults []*TaskResult, err error) {
 			return nil, ErrLastReturnValueMustBeError
 		}
 
-		_, isRetriable := asError.(Retriable)
+		_, isRetryable := asError.(Retryable)
 
 		if span != nil {
-			if !isRetriable {
+			if !isRetryable {
 				span.LogFields(opentracing_log.Error(asError))
 			} else {
 				span.SetTag("warning", asError)
 			}
 
-			span.SetTag("can_retry", isRetriable)
+			span.SetTag("can_retry", isRetryable)
 			span.SetTag("did_fail", true)
 		}
 


### PR DESCRIPTION
Using delays, converting to an ETA, and then back to a duration effectively floors the delay.