### PR TITLE
SQS receive call requests first receive timestamp

### DIFF
--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -364,6 +364,7 @@ func (b *Broker) receiveMessage(qURL *string) (*awssqs.ReceiveMessageOutput, err
 		AttributeNames: []*string{
 			aws.String(awssqs.MessageSystemAttributeNameSentTimestamp),
 			aws.String(awssqs.MessageSystemAttributeNameApproximateReceiveCount),
+			aws.String(awssqs.MessageSystemAttributeNameApproximateFirstReceiveTimestamp),
 		},
 		MessageAttributeNames: []*string{
 			aws.String(awssqs.QueueAttributeNameAll),


### PR DESCRIPTION
Machinery doesn't request the `ApproximateFirstReceiveTimestamp` attribute when dequeuing messages, so SQS doesn't return it. Since it's not returned, we read it as nil and this results in nonsense log values