### PR TITLE
Improve backend error tolerance

### DIFF
--- a/v1/brokers/sqs/sqs_export_test.go
+++ b/v1/brokers/sqs/sqs_export_test.go
@@ -147,7 +147,8 @@ func NewTestErrorBroker() *Broker {
 }
 
 func (b *Broker) ConsumeForTest(deliveries <-chan *awssqs.ReceiveMessageOutput, taskProcessor iface.TaskProcessor, concurrency iface.ResizeablePool) error {
-	return b.consume(deliveries, taskProcessor, concurrency)
+	panic("not implemented")
+	return nil
 }
 
 func (b *Broker) ConsumeOneForTest(delivery *awssqs.ReceiveMessageOutput, taskProcessor iface.TaskProcessor) error {
@@ -171,11 +172,13 @@ func (b *Broker) InitializePoolForTest(pool chan struct{}, concurrency int) {
 }
 
 func (b *Broker) ConsumeDeliveriesForTest(deliveries <-chan *awssqs.ReceiveMessageOutput, taskProcessor iface.TaskProcessor, concurrency iface.ResizeablePool, errorsChan chan error) (bool, error) {
-	return b.consumeDeliveries(deliveries, taskProcessor, concurrency, errorsChan)
+	panic("not implemented")
+	return false, nil
 }
 
 func (b *Broker) ContinueReceivingMessagesForTest(qURL *string, deliveries chan *awssqs.ReceiveMessageOutput) (bool, error) {
-	return b.continueReceivingMessages(qURL, deliveries)
+	panic("not implemented")
+	return false, nil
 }
 
 func (b *Broker) StopReceivingForTest() {

--- a/v1/brokers/sqs/sqs_test.go
+++ b/v1/brokers/sqs/sqs_test.go
@@ -102,7 +102,7 @@ func TestPrivateFunc_consume(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	concurrency := common.NewResizablePool(1)
+	concurrency, _ := common.NewResizablePool(1)
 	wk := server1.NewWorker("sms_worker", 0)
 	deliveries := make(chan *awssqs.ReceiveMessageOutput)
 	outputCopy := *receiveMessageOutput
@@ -204,7 +204,7 @@ func TestPrivateFunc_receiveMessage(t *testing.T) {
 
 func TestPrivateFunc_consumeDeliveries(t *testing.T) {
 
-	concurrency := common.NewResizablePool(0)
+	concurrency, _ := common.NewResizablePool(0)
 	errorsChan := make(chan error)
 	deliveries := make(chan *awssqs.ReceiveMessageOutput)
 	server1, err := machinery.NewServer(cnf)
@@ -319,7 +319,7 @@ func TestPrivateFunc_consumeWithConcurrency(t *testing.T) {
 	broker.SetRegisteredTaskNames([]string{"test-task"})
 	assert.NoError(t, err)
 
-	concurrency := common.NewResizablePool(1)
+	concurrency, _ := common.NewResizablePool(1)
 	wk := server1.NewWorker("sms_worker", 1)
 	deliveries := make(chan *awssqs.ReceiveMessageOutput)
 	outputCopy := *receiveMessageOutput


### PR DESCRIPTION
Improve SQS broker reliability when backend returns errors
Originally, the SQS broker created a goroutine with an infinite loop. That
goroutine would poll SQS and put any received messages on a channel. A separate
goroutine would poll that channel, spawning a goroutine for any received items.
A separate channel reported errors between these different goroutines. In
theory, all the goroutines would listen for channel closure and error channel
items to handle errors. Unfortunately, if the backend reports errors then
polling the queue would quickly stop, because in this case the currency pool
wasn't properly returned.

To address this, the multiple goroutines are collapsed. When the initial
pollying goroutine receives a message, it immediately spawns a goroutine to
process that message, rather than using a channel and intermediate goroutine.
In addition, it always returns to the concurrency pool immediately after either
encountering an error or processing a message. This allows polling and
processing to continue even if the backend reports an error.

https://www.notion.so/sublimesecurity/Investigate-and-resolve-Redis-failure-halting-machinery-processing-12704655fc9d8185a4fbc29071ca6986?pvs=4