### PR TITLE
Fix issue with delayed tasks for Redis brokers

### DIFF
--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -174,6 +174,8 @@ func (b *BrokerGR) Publish(ctx context.Context, signature *tasks.Signature) erro
 	// Adjust routing key (this decides which queue the message will be published to)
 	b.Broker.AdjustRoutingKey(signature)
 
+	// We'll capture the delay here and set it to zero in the signature because otherwise
+	// the task will be continously delayed.
 	delay := signature.Delay
 	signature.Delay = 0
 	msg, err := json.Marshal(signature)
@@ -181,8 +183,6 @@ func (b *BrokerGR) Publish(ctx context.Context, signature *tasks.Signature) erro
 		return fmt.Errorf("JSON marshal error: %s", err)
 	}
 
-	// Check the delay signature field, if it is set and it is in the future,
-	// delay the task
 	if delay > 0 {
 		score := time.Now().Add(delay).UnixNano()
 		err = b.rclient.ZAdd(context.Background(), b.redisDelayedTasksKey, redis.Z{Score: float64(score), Member: msg}).Err()

--- a/v1/brokers/redis/goredis.go
+++ b/v1/brokers/redis/goredis.go
@@ -174,6 +174,8 @@ func (b *BrokerGR) Publish(ctx context.Context, signature *tasks.Signature) erro
 	// Adjust routing key (this decides which queue the message will be published to)
 	b.Broker.AdjustRoutingKey(signature)
 
+	delay := signature.Delay
+	signature.Delay = 0
 	msg, err := json.Marshal(signature)
 	if err != nil {
 		return fmt.Errorf("JSON marshal error: %s", err)
@@ -181,8 +183,8 @@ func (b *BrokerGR) Publish(ctx context.Context, signature *tasks.Signature) erro
 
 	// Check the delay signature field, if it is set and it is in the future,
 	// delay the task
-	if signature.Delay > 0 {
-		score := time.Now().Add(signature.Delay).UnixNano()
+	if delay > 0 {
+		score := time.Now().Add(delay).UnixNano()
 		err = b.rclient.ZAdd(context.Background(), b.redisDelayedTasksKey, redis.Z{Score: float64(score), Member: msg}).Err()
 		return err
 	}

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -184,6 +184,8 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	// Adjust routing key (this decides which queue the message will be published to)
 	b.Broker.AdjustRoutingKey(signature)
 
+	delay := signature.Delay
+	signature.Delay = 0
 	msg, err := json.Marshal(signature)
 	if err != nil {
 		return fmt.Errorf("JSON marshal error: %s", err)
@@ -194,8 +196,8 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 
 	// Check the delay signature field, if it is set and it is in the future,
 	// delay the task
-	if signature.Delay > 0 {
-		score := time.Now().Add(signature.Delay).UnixNano()
+	if delay > 0 {
+		score := time.Now().Add(delay).UnixNano()
 		_, err = conn.Do("ZADD", b.redisDelayedTasksKey, score, msg)
 		return err
 	}

--- a/v1/brokers/redis/redis.go
+++ b/v1/brokers/redis/redis.go
@@ -184,6 +184,8 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	// Adjust routing key (this decides which queue the message will be published to)
 	b.Broker.AdjustRoutingKey(signature)
 
+	// We'll capture the delay here and set it to zero in the signature because otherwise
+	// the task will be continously delayed.
 	delay := signature.Delay
 	signature.Delay = 0
 	msg, err := json.Marshal(signature)
@@ -194,8 +196,6 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	conn := b.open()
 	defer conn.Close()
 
-	// Check the delay signature field, if it is set and it is in the future,
-	// delay the task
 	if delay > 0 {
 		score := time.Now().Add(delay).UnixNano()
 		_, err = conn.Do("ZADD", b.redisDelayedTasksKey, score, msg)


### PR DESCRIPTION
This fixes an issue where tasks that were queued with a `Delay` greater than 0 would keep getting placed back into the delayed tasks queue. Now when we go to publish a delayed task we'll clear out the `signature.Delay` so the next time we grab it it's enqueued appropriately. I tested this by editing the file locally and starting delayed tasks. The tasks were delayed correctly and forwarded to the appropriate queue after the delay.