### PR TITLE
Pass through redis TLS config

### DIFF
--- a/v2/backends/redis/goredis.go
+++ b/v2/backends/redis/goredis.go
@@ -47,6 +47,7 @@ func NewGR(cnf *config.Config, addrs []string, db int) iface.Backend {
 		Addrs:    addrs,
 		DB:       db,
 		Password: b.password,
+		TLSConfig: cnf.TLSConfig,
 	}
 	if cnf.Redis != nil {
 		ropt.MasterName = cnf.Redis.MasterName


### PR DESCRIPTION
This will enable support for TLS w redis replication groups or clusters.