### PR TITLE
test: storage queues test coverage

### DIFF
--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -22,6 +22,13 @@ const (
 	maxDelay = time.Minute * 7 // Max supported Visibility Timeout
 )
 
+type queueClient interface {
+	EnqueueMessage(ctx context.Context, content string, o *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error)
+	DequeueMessage(ctx context.Context, o *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error)
+	UpdateMessage(ctx context.Context, messageID string, popReceipt string, content string, o *azqueue.UpdateMessageOptions) (azqueue.UpdateMessageResponse, error)
+	DeleteMessage(ctx context.Context, messageID string, popReceipt string, o *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error)
+}
+
 // Broker represents an Azure Storage Queue broker
 type Broker struct {
 	common.Broker
@@ -30,6 +37,7 @@ type Broker struct {
 	stopReceivingChan chan int
 	cfg               config.AzureConfig
 	queueName         string
+	newQueueClient    func(string) queueClient
 }
 
 // New creates new Broker instance
@@ -37,6 +45,9 @@ func New(cnf *config.Config) iface.Broker {
 	b := &Broker{Broker: common.NewBroker(cnf)}
 	b.cfg = *cnf.Azure
 	b.queueName = cnf.DefaultQueue
+	b.newQueueClient = func(name string) queueClient {
+		return cnf.Azure.Client.NewQueueClient(name)
+	}
 
 	return b
 }
@@ -177,7 +188,7 @@ func (b *Broker) Publish(ctx context.Context, signature *tasks.Signature) error 
 	ttlSeconds := int32(b.cfg.TTL.Seconds())
 	enqueueOptions.TimeToLive = &ttlSeconds
 
-	result, err := b.cfg.Client.NewQueueClient(signature.RoutingKey).EnqueueMessage(ctx, messageBody, enqueueOptions)
+	result, err := b.newQueueClient(signature.RoutingKey).EnqueueMessage(ctx, messageBody, enqueueOptions)
 
 	if err != nil {
 		log.ERROR.Printf("Error when sending a message: %v", err)
@@ -197,7 +208,7 @@ func (b *Broker) extend(by time.Duration, signature *tasks.Signature) error {
 
 	delayS := int32(by.Seconds())
 
-	_, err := b.cfg.Client.NewQueueClient(signature.RoutingKey).UpdateMessage(
+	_, err := b.newQueueClient(signature.RoutingKey).UpdateMessage(
 		context.Background(),
 		signature.AzureMessageID,
 		signature.AzurePopReceipt,
@@ -215,7 +226,7 @@ func (b *Broker) RetryMessage(signature *tasks.Signature) {
 
 	delayS := int32(signature.Delay.Seconds())
 
-	_, err := b.cfg.Client.NewQueueClient(signature.RoutingKey).UpdateMessage(
+	_, err := b.newQueueClient(signature.RoutingKey).UpdateMessage(
 		context.Background(),
 		signature.AzureMessageID,
 		signature.AzurePopReceipt,
@@ -311,7 +322,7 @@ func (b *Broker) consumeOne(delivery azqueue.DequeueMessagesResponse, taskProces
 
 // deleteOne is a method delete a delivery from AWS SQS
 func (b *Broker) deleteOne(message *azqueue.DequeuedMessage) error {
-	_, err := b.cfg.Client.NewQueueClient(b.queueName).DeleteMessage(context.Background(), *message.MessageID, *message.PopReceipt, nil)
+	_, err := b.newQueueClient(b.queueName).DeleteMessage(context.Background(), *message.MessageID, *message.PopReceipt, nil)
 	if err != nil {
 		return err
 	}
@@ -321,7 +332,7 @@ func (b *Broker) deleteOne(message *azqueue.DequeuedMessage) error {
 // receiveMessage is a method receives a message from specified queue url
 func (b *Broker) receiveMessage() (azqueue.DequeueMessagesResponse, error) {
 	visibilityTimeoutS := int32(b.cfg.VisibilityTimeout.Seconds())
-	result, err := b.cfg.Client.NewQueueClient(b.queueName).DequeueMessage(context.Background(), &azqueue.DequeueMessageOptions{VisibilityTimeout: &visibilityTimeoutS})
+	result, err := b.newQueueClient(b.queueName).DequeueMessage(context.Background(), &azqueue.DequeueMessageOptions{VisibilityTimeout: &visibilityTimeoutS})
 	if err != nil {
 		return azqueue.DequeueMessagesResponse{}, err
 	}

--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -22,8 +22,7 @@ const (
 	maxDelay = time.Minute * 7 // Max supported Visibility Timeout
 )
 
-// Broker represents a AWS SQS broker
-// There are examples on: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/sqs-example-create-queue.html
+// Broker represents an Azure Storage Queue broker
 type Broker struct {
 	common.Broker
 	processingWG      sync.WaitGroup // use wait group to make sure task processing completes on interrupt signal

--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -42,7 +42,7 @@ func New(cnf *config.Config) iface.Broker {
 	return b
 }
 
-var badRequestErrRegex = regexp.MustCompile(`4[\d][\d]`)
+var badRequestErrRegex = regexp.MustCompile(`4\d\d`)
 
 // StartConsuming enters a loop and waits for incoming messages
 func (b *Broker) StartConsuming(consumerTag string, concurrency iface.ResizeablePool, taskProcessor iface.TaskProcessor) (bool, error) {

--- a/v1/brokers/azure/storage_queue_export_test.go
+++ b/v1/brokers/azure/storage_queue_export_test.go
@@ -21,7 +21,12 @@ func NewTestBroker() *Broker {
 		stopReceivingChan: make(chan int),
 		cfg:               *cnf.Azure,
 		queueName:         cnf.DefaultQueue,
+		newQueueClient:    func(name string) queueClient { return nil },
 	}
+}
+
+func (b *Broker) SetQueueClientFactoryForTest(fn func(string) queueClient) {
+	b.newQueueClient = fn
 }
 
 func (b *Broker) InitializePoolForTest(pool chan struct{}, concurrency int) {

--- a/v1/brokers/azure/storage_queue_export_test.go
+++ b/v1/brokers/azure/storage_queue_export_test.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"context"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
@@ -27,6 +28,46 @@ func NewTestBroker() *Broker {
 
 func (b *Broker) SetQueueClientFactoryForTest(fn func(string) queueClient) {
 	b.newQueueClient = fn
+}
+
+// MockClient is an exported queueClient implementation for use in external test packages.
+type MockClient struct {
+	EnqueueFunc func(ctx context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error)
+	DequeueFunc func(ctx context.Context, opts *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error)
+	UpdateFunc  func(ctx context.Context, messageID, popReceipt, content string, opts *azqueue.UpdateMessageOptions) (azqueue.UpdateMessageResponse, error)
+	DeleteFunc  func(ctx context.Context, messageID, popReceipt string, opts *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error)
+}
+
+func (m *MockClient) EnqueueMessage(ctx context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+	if m.EnqueueFunc != nil {
+		return m.EnqueueFunc(ctx, content, opts)
+	}
+	return azqueue.EnqueueMessagesResponse{}, nil
+}
+
+func (m *MockClient) DequeueMessage(ctx context.Context, opts *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
+	if m.DequeueFunc != nil {
+		return m.DequeueFunc(ctx, opts)
+	}
+	return azqueue.DequeueMessagesResponse{}, nil
+}
+
+func (m *MockClient) UpdateMessage(ctx context.Context, messageID, popReceipt, content string, opts *azqueue.UpdateMessageOptions) (azqueue.UpdateMessageResponse, error) {
+	if m.UpdateFunc != nil {
+		return m.UpdateFunc(ctx, messageID, popReceipt, content, opts)
+	}
+	return azqueue.UpdateMessageResponse{}, nil
+}
+
+func (m *MockClient) DeleteMessage(ctx context.Context, messageID, popReceipt string, opts *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, messageID, popReceipt, opts)
+	}
+	return azqueue.DeleteMessageResponse{}, nil
+}
+
+func (b *Broker) SetMockClientForTest(c *MockClient) {
+	b.newQueueClient = func(string) queueClient { return c }
 }
 
 func (b *Broker) InitializePoolForTest(pool chan struct{}, concurrency int) {

--- a/v1/brokers/azure/storage_queue_export_test.go
+++ b/v1/brokers/azure/storage_queue_export_test.go
@@ -1,0 +1,41 @@
+package azure
+
+import (
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+	"github.com/RichardKnop/machinery/v1/brokers/iface"
+	"github.com/RichardKnop/machinery/v1/common"
+	"github.com/RichardKnop/machinery/v1/config"
+)
+
+func NewTestBroker() *Broker {
+	cnf := &config.Config{
+		DefaultQueue: "test_queue",
+		Azure:        &config.AzureConfig{},
+	}
+	return &Broker{
+		Broker:            common.NewBroker(cnf),
+		processingWG:      sync.WaitGroup{},
+		receivingWG:       sync.WaitGroup{},
+		stopReceivingChan: make(chan int),
+		cfg:               *cnf.Azure,
+		queueName:         cnf.DefaultQueue,
+	}
+}
+
+func (b *Broker) InitializePoolForTest(pool chan struct{}, concurrency int) {
+	b.initializePool(pool, concurrency)
+}
+
+func (b *Broker) StopReceivingForTest() {
+	b.stopReceiving()
+}
+
+func (b *Broker) GetStopReceivingChanForTest() chan int {
+	return b.stopReceivingChan
+}
+
+func (b *Broker) ConsumeOneForTest(delivery azqueue.DequeueMessagesResponse, taskProcessor iface.TaskProcessor) error {
+	return b.consumeOne(delivery, taskProcessor)
+}

--- a/v1/brokers/azure/storage_queue_internal_test.go
+++ b/v1/brokers/azure/storage_queue_internal_test.go
@@ -1,0 +1,35 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBadRequestErrRegex(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		match bool
+	}{
+		{"400", true},
+		{"401", true},
+		{"403", true},
+		{"404", true},
+		{"499", true},
+		{"200", false},
+		{"301", false},
+		{"500", false},
+		{"503", false},
+		{"some 400 error", true},
+		{"some 500 error", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.match, badRequestErrRegex.MatchString(tc.input))
+		})
+	}
+}

--- a/v1/brokers/azure/storage_queue_internal_test.go
+++ b/v1/brokers/azure/storage_queue_internal_test.go
@@ -1,10 +1,78 @@
 package azure
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+	"github.com/RichardKnop/machinery/v1/brokers/errs"
+	"github.com/RichardKnop/machinery/v1/tasks"
 	"github.com/stretchr/testify/assert"
 )
+
+// mockQueueClient implements queueClient for tests.
+type mockQueueClient struct {
+	enqueueFunc func(ctx context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error)
+	dequeueFunc func(ctx context.Context, opts *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error)
+	updateFunc  func(ctx context.Context, messageID, popReceipt, content string, opts *azqueue.UpdateMessageOptions) (azqueue.UpdateMessageResponse, error)
+	deleteFunc  func(ctx context.Context, messageID, popReceipt string, opts *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error)
+}
+
+func (m *mockQueueClient) EnqueueMessage(ctx context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+	if m.enqueueFunc != nil {
+		return m.enqueueFunc(ctx, content, opts)
+	}
+	return azqueue.EnqueueMessagesResponse{}, nil
+}
+
+func (m *mockQueueClient) DequeueMessage(ctx context.Context, opts *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
+	if m.dequeueFunc != nil {
+		return m.dequeueFunc(ctx, opts)
+	}
+	return azqueue.DequeueMessagesResponse{}, nil
+}
+
+func (m *mockQueueClient) UpdateMessage(ctx context.Context, messageID, popReceipt, content string, opts *azqueue.UpdateMessageOptions) (azqueue.UpdateMessageResponse, error) {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, messageID, popReceipt, content, opts)
+	}
+	return azqueue.UpdateMessageResponse{}, nil
+}
+
+func (m *mockQueueClient) DeleteMessage(ctx context.Context, messageID, popReceipt string, opts *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, messageID, popReceipt, opts)
+	}
+	return azqueue.DeleteMessageResponse{}, nil
+}
+
+// mockTaskProcessor implements iface.TaskProcessor for tests.
+type mockTaskProcessor struct {
+	processFunc func(sig *tasks.Signature, extendFunc tasks.ExtendForSignatureFunc) error
+}
+
+func (m *mockTaskProcessor) Process(sig *tasks.Signature, extendFunc tasks.ExtendForSignatureFunc) error {
+	if m.processFunc != nil {
+		return m.processFunc(sig, extendFunc)
+	}
+	return nil
+}
+
+func (m *mockTaskProcessor) CustomQueue() string    { return "" }
+func (m *mockTaskProcessor) PreConsumeHandler() bool { return true }
+
+func makeDelivery(msgText, msgID, popReceipt string) azqueue.DequeueMessagesResponse {
+	return azqueue.DequeueMessagesResponse{
+		Messages: []*azqueue.DequeuedMessage{{
+			MessageID:   &msgID,
+			PopReceipt:  &popReceipt,
+			MessageText: &msgText,
+		}},
+	}
+}
 
 func TestBadRequestErrRegex(t *testing.T) {
 	t.Parallel()
@@ -32,4 +100,302 @@ func TestBadRequestErrRegex(t *testing.T) {
 			assert.Equal(t, tc.match, badRequestErrRegex.MatchString(tc.input))
 		})
 	}
+}
+
+func TestConsumeOne_ValidMessage_Success(t *testing.T) {
+	sig := &tasks.Signature{Name: "test_task", UUID: "abc123"}
+	msgText, _ := json.Marshal(sig)
+
+	var deletedID string
+	client := &mockQueueClient{
+		deleteFunc: func(_ context.Context, messageID, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+			deletedID = messageID
+			return azqueue.DeleteMessageResponse{}, nil
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.SetRegisteredTaskNames([]string{"test_task"})
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	err := broker.consumeOne(makeDelivery(string(msgText), "msg-id", "pop-receipt"), &mockTaskProcessor{})
+	assert.NoError(t, err)
+	assert.Equal(t, "msg-id", deletedID)
+}
+
+func TestConsumeOne_InvalidJSON(t *testing.T) {
+	deleted := false
+	client := &mockQueueClient{
+		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+			deleted = true
+			return azqueue.DeleteMessageResponse{}, nil
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	err := broker.consumeOne(makeDelivery("not valid json", "msg-id", "pop-receipt"), nil)
+	assert.Error(t, err)
+	assert.True(t, deleted)
+}
+
+func TestConsumeOne_UnregisteredTask(t *testing.T) {
+	deleted := false
+	client := &mockQueueClient{
+		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+			deleted = true
+			return azqueue.DeleteMessageResponse{}, nil
+		},
+	}
+
+	sig := &tasks.Signature{Name: "unknown_task", UUID: "abc123"}
+	msgText, _ := json.Marshal(sig)
+
+	broker := NewTestBroker()
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	err := broker.consumeOne(makeDelivery(string(msgText), "msg-id", "pop-receipt"), nil)
+	assert.ErrorContains(t, err, "is not registered")
+	assert.False(t, deleted)
+}
+
+func TestConsumeOne_IgnoreWhenNotRegistered(t *testing.T) {
+	deleted := false
+	client := &mockQueueClient{
+		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+			deleted = true
+			return azqueue.DeleteMessageResponse{}, nil
+		},
+	}
+
+	sig := &tasks.Signature{Name: "unknown_task", UUID: "abc123", IgnoreWhenTaskNotRegistered: true}
+	msgText, _ := json.Marshal(sig)
+
+	broker := NewTestBroker()
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	err := broker.consumeOne(makeDelivery(string(msgText), "msg-id", "pop-receipt"), nil)
+	assert.ErrorContains(t, err, "is not registered")
+	assert.True(t, deleted)
+}
+
+func TestConsumeOne_StopTaskDeletion(t *testing.T) {
+	deleted := false
+	client := &mockQueueClient{
+		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+			deleted = true
+			return azqueue.DeleteMessageResponse{}, nil
+		},
+	}
+
+	tp := &mockTaskProcessor{
+		processFunc: func(_ *tasks.Signature, _ tasks.ExtendForSignatureFunc) error {
+			return errs.ErrStopTaskDeletion
+		},
+	}
+
+	sig := &tasks.Signature{Name: "test_task", UUID: "abc123"}
+	msgText, _ := json.Marshal(sig)
+
+	broker := NewTestBroker()
+	broker.SetRegisteredTaskNames([]string{"test_task"})
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	err := broker.consumeOne(makeDelivery(string(msgText), "msg-id", "pop-receipt"), tp)
+	assert.NoError(t, err)
+	assert.False(t, deleted)
+}
+
+func TestPublish_NoDelay(t *testing.T) {
+	var capturedContent string
+	var capturedOpts *azqueue.EnqueueMessageOptions
+	msgID := "msg-id"
+
+	client := &mockQueueClient{
+		enqueueFunc: func(_ context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+			capturedContent = content
+			capturedOpts = opts
+			return azqueue.EnqueueMessagesResponse{
+				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
+			}, nil
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	sig := &tasks.Signature{Name: "test_task", UUID: "abc123"}
+	err := broker.Publish(context.Background(), sig)
+	assert.NoError(t, err)
+
+	var decoded tasks.Signature
+	assert.NoError(t, json.Unmarshal([]byte(capturedContent), &decoded))
+	assert.Equal(t, "test_task", decoded.Name)
+	assert.Nil(t, capturedOpts.VisibilityTimeout)
+}
+
+func TestPublish_TTL(t *testing.T) {
+	var capturedOpts *azqueue.EnqueueMessageOptions
+	msgID := "msg-id"
+
+	client := &mockQueueClient{
+		enqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+			capturedOpts = opts
+			return azqueue.EnqueueMessagesResponse{
+				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
+			}, nil
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.cfg.TTL = time.Hour
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	sig := &tasks.Signature{Name: "test_task", UUID: "abc123"}
+	err := broker.Publish(context.Background(), sig)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(3600), *capturedOpts.TimeToLive)
+}
+
+func TestPublish_WithDelay(t *testing.T) {
+	var capturedOpts *azqueue.EnqueueMessageOptions
+	msgID := "msg-id"
+
+	client := &mockQueueClient{
+		enqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+			capturedOpts = opts
+			return azqueue.EnqueueMessagesResponse{
+				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
+			}, nil
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.cfg.TTL = time.Hour
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	sig := &tasks.Signature{Name: "test_task", UUID: "abc123", Delay: 30 * time.Second}
+	err := broker.Publish(context.Background(), sig)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(30), *capturedOpts.VisibilityTimeout)
+}
+
+func TestPublish_DelayExceedsMax(t *testing.T) {
+	var capturedOpts *azqueue.EnqueueMessageOptions
+	msgID := "msg-id"
+
+	client := &mockQueueClient{
+		enqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+			capturedOpts = opts
+			return azqueue.EnqueueMessagesResponse{
+				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
+			}, nil
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.cfg.TTL = time.Hour
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	sig := &tasks.Signature{Name: "test_task", UUID: "abc123", Delay: maxDelay + time.Second}
+	err := broker.Publish(context.Background(), sig)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(maxDelay.Seconds()), *capturedOpts.VisibilityTimeout)
+}
+
+func TestPublish_EnqueueError(t *testing.T) {
+	client := &mockQueueClient{
+		enqueueFunc: func(_ context.Context, _ string, _ *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+			return azqueue.EnqueueMessagesResponse{}, fmt.Errorf("network error")
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	sig := &tasks.Signature{Name: "test_task", UUID: "abc123"}
+	err := broker.Publish(context.Background(), sig)
+	assert.ErrorContains(t, err, "network error")
+}
+
+func TestReceiveMessage(t *testing.T) {
+	msgID := "msg-id"
+	popReceipt := "pop-receipt"
+	msgText := "hello"
+
+	var capturedOpts *azqueue.DequeueMessageOptions
+	client := &mockQueueClient{
+		dequeueFunc: func(_ context.Context, opts *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
+			capturedOpts = opts
+			return azqueue.DequeueMessagesResponse{
+				Messages: []*azqueue.DequeuedMessage{{
+					MessageID:   &msgID,
+					PopReceipt:  &popReceipt,
+					MessageText: &msgText,
+				}},
+			}, nil
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.cfg.VisibilityTimeout = 30 * time.Second
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	result, err := broker.receiveMessage()
+	assert.NoError(t, err)
+	assert.Len(t, result.Messages, 1)
+	assert.Equal(t, "msg-id", *result.Messages[0].MessageID)
+	assert.Equal(t, int32(30), *capturedOpts.VisibilityTimeout)
+}
+
+func TestReceiveMessage_Error(t *testing.T) {
+	client := &mockQueueClient{
+		dequeueFunc: func(_ context.Context, _ *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
+			return azqueue.DequeueMessagesResponse{}, fmt.Errorf("dequeue error")
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	_, err := broker.receiveMessage()
+	assert.ErrorContains(t, err, "dequeue error")
+}
+
+func TestDeleteOne(t *testing.T) {
+	var deletedID, deletedReceipt string
+	client := &mockQueueClient{
+		deleteFunc: func(_ context.Context, messageID, popReceipt string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+			deletedID = messageID
+			deletedReceipt = popReceipt
+			return azqueue.DeleteMessageResponse{}, nil
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	msgID := "msg-id"
+	popReceipt := "pop-receipt"
+	err := broker.deleteOne(&azqueue.DequeuedMessage{MessageID: &msgID, PopReceipt: &popReceipt})
+	assert.NoError(t, err)
+	assert.Equal(t, "msg-id", deletedID)
+	assert.Equal(t, "pop-receipt", deletedReceipt)
+}
+
+func TestDeleteOne_Error(t *testing.T) {
+	client := &mockQueueClient{
+		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+			return azqueue.DeleteMessageResponse{}, fmt.Errorf("delete error")
+		},
+	}
+
+	broker := NewTestBroker()
+	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+
+	msgID := "msg-id"
+	popReceipt := "pop-receipt"
+	err := broker.deleteOne(&azqueue.DequeuedMessage{MessageID: &msgID, PopReceipt: &popReceipt})
+	assert.ErrorContains(t, err, "delete error")
 }

--- a/v1/brokers/azure/storage_queue_internal_test.go
+++ b/v1/brokers/azure/storage_queue_internal_test.go
@@ -174,14 +174,13 @@ func TestConsumeOne_StopTaskDeletion(t *testing.T) {
 func TestPublish_NoDelay(t *testing.T) {
 	var capturedContent string
 	var capturedOpts *azqueue.EnqueueMessageOptions
-	msgID := "msg-id"
 
 	client := &MockClient{
 		EnqueueFunc: func(_ context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
 			capturedContent = content
 			capturedOpts = opts
 			return azqueue.EnqueueMessagesResponse{
-				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
+				Messages: []*azqueue.EnqueuedMessage{{MessageID: new("msg-id")}},
 			}, nil
 		},
 	}
@@ -201,13 +200,12 @@ func TestPublish_NoDelay(t *testing.T) {
 
 func TestPublish_TTL(t *testing.T) {
 	var capturedOpts *azqueue.EnqueueMessageOptions
-	msgID := "msg-id"
 
 	client := &MockClient{
 		EnqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
 			capturedOpts = opts
 			return azqueue.EnqueueMessagesResponse{
-				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
+				Messages: []*azqueue.EnqueuedMessage{{MessageID: new("msg-id")}},
 			}, nil
 		},
 	}
@@ -224,13 +222,12 @@ func TestPublish_TTL(t *testing.T) {
 
 func TestPublish_WithDelay(t *testing.T) {
 	var capturedOpts *azqueue.EnqueueMessageOptions
-	msgID := "msg-id"
 
 	client := &MockClient{
 		EnqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
 			capturedOpts = opts
 			return azqueue.EnqueueMessagesResponse{
-				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
+				Messages: []*azqueue.EnqueuedMessage{{MessageID: new("msg-id")}},
 			}, nil
 		},
 	}
@@ -247,13 +244,12 @@ func TestPublish_WithDelay(t *testing.T) {
 
 func TestPublish_DelayExceedsMax(t *testing.T) {
 	var capturedOpts *azqueue.EnqueueMessageOptions
-	msgID := "msg-id"
 
 	client := &MockClient{
 		EnqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
 			capturedOpts = opts
 			return azqueue.EnqueueMessagesResponse{
-				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
+				Messages: []*azqueue.EnqueuedMessage{{MessageID: new("msg-id")}},
 			}, nil
 		},
 	}
@@ -285,8 +281,6 @@ func TestPublish_EnqueueError(t *testing.T) {
 
 func TestReceiveMessage(t *testing.T) {
 	msgID := "msg-id"
-	popReceipt := "pop-receipt"
-	msgText := "hello"
 
 	var capturedOpts *azqueue.DequeueMessageOptions
 	client := &MockClient{
@@ -295,8 +289,8 @@ func TestReceiveMessage(t *testing.T) {
 			return azqueue.DequeueMessagesResponse{
 				Messages: []*azqueue.DequeuedMessage{{
 					MessageID:   &msgID,
-					PopReceipt:  &popReceipt,
-					MessageText: &msgText,
+					PopReceipt:  new("pop-receipt"),
+					MessageText: new("hello"),
 				}},
 			}, nil
 		},
@@ -309,7 +303,7 @@ func TestReceiveMessage(t *testing.T) {
 	result, err := broker.receiveMessage()
 	assert.NoError(t, err)
 	assert.Len(t, result.Messages, 1)
-	assert.Equal(t, "msg-id", *result.Messages[0].MessageID)
+	assert.Equal(t, msgID, *result.Messages[0].MessageID)
 	assert.Equal(t, int32(30), *capturedOpts.VisibilityTimeout)
 }
 
@@ -340,9 +334,7 @@ func TestDeleteOne(t *testing.T) {
 	broker := NewTestBroker()
 	broker.SetMockClientForTest(client)
 
-	msgID := "msg-id"
-	popReceipt := "pop-receipt"
-	err := broker.deleteOne(&azqueue.DequeuedMessage{MessageID: &msgID, PopReceipt: &popReceipt})
+	err := broker.deleteOne(&azqueue.DequeuedMessage{MessageID: new("msg-id"), PopReceipt: new("pop-receipt")})
 	assert.NoError(t, err)
 	assert.Equal(t, "msg-id", deletedID)
 	assert.Equal(t, "pop-receipt", deletedReceipt)
@@ -358,8 +350,6 @@ func TestDeleteOne_Error(t *testing.T) {
 	broker := NewTestBroker()
 	broker.SetMockClientForTest(client)
 
-	msgID := "msg-id"
-	popReceipt := "pop-receipt"
-	err := broker.deleteOne(&azqueue.DequeuedMessage{MessageID: &msgID, PopReceipt: &popReceipt})
+	err := broker.deleteOne(&azqueue.DequeuedMessage{MessageID: new("msg-id"), PopReceipt: new("pop-receipt")})
 	assert.ErrorContains(t, err, "delete error")
 }

--- a/v1/brokers/azure/storage_queue_internal_test.go
+++ b/v1/brokers/azure/storage_queue_internal_test.go
@@ -13,42 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// mockQueueClient implements queueClient for tests.
-type mockQueueClient struct {
-	enqueueFunc func(ctx context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error)
-	dequeueFunc func(ctx context.Context, opts *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error)
-	updateFunc  func(ctx context.Context, messageID, popReceipt, content string, opts *azqueue.UpdateMessageOptions) (azqueue.UpdateMessageResponse, error)
-	deleteFunc  func(ctx context.Context, messageID, popReceipt string, opts *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error)
-}
-
-func (m *mockQueueClient) EnqueueMessage(ctx context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
-	if m.enqueueFunc != nil {
-		return m.enqueueFunc(ctx, content, opts)
-	}
-	return azqueue.EnqueueMessagesResponse{}, nil
-}
-
-func (m *mockQueueClient) DequeueMessage(ctx context.Context, opts *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
-	if m.dequeueFunc != nil {
-		return m.dequeueFunc(ctx, opts)
-	}
-	return azqueue.DequeueMessagesResponse{}, nil
-}
-
-func (m *mockQueueClient) UpdateMessage(ctx context.Context, messageID, popReceipt, content string, opts *azqueue.UpdateMessageOptions) (azqueue.UpdateMessageResponse, error) {
-	if m.updateFunc != nil {
-		return m.updateFunc(ctx, messageID, popReceipt, content, opts)
-	}
-	return azqueue.UpdateMessageResponse{}, nil
-}
-
-func (m *mockQueueClient) DeleteMessage(ctx context.Context, messageID, popReceipt string, opts *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
-	if m.deleteFunc != nil {
-		return m.deleteFunc(ctx, messageID, popReceipt, opts)
-	}
-	return azqueue.DeleteMessageResponse{}, nil
-}
-
 // mockTaskProcessor implements iface.TaskProcessor for tests.
 type mockTaskProcessor struct {
 	processFunc func(sig *tasks.Signature, extendFunc tasks.ExtendForSignatureFunc) error
@@ -61,7 +25,7 @@ func (m *mockTaskProcessor) Process(sig *tasks.Signature, extendFunc tasks.Exten
 	return nil
 }
 
-func (m *mockTaskProcessor) CustomQueue() string    { return "" }
+func (m *mockTaskProcessor) CustomQueue() string     { return "" }
 func (m *mockTaskProcessor) PreConsumeHandler() bool { return true }
 
 func makeDelivery(msgText, msgID, popReceipt string) azqueue.DequeueMessagesResponse {
@@ -107,8 +71,8 @@ func TestConsumeOne_ValidMessage_Success(t *testing.T) {
 	msgText, _ := json.Marshal(sig)
 
 	var deletedID string
-	client := &mockQueueClient{
-		deleteFunc: func(_ context.Context, messageID, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+	client := &MockClient{
+		DeleteFunc: func(_ context.Context, messageID, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
 			deletedID = messageID
 			return azqueue.DeleteMessageResponse{}, nil
 		},
@@ -116,7 +80,7 @@ func TestConsumeOne_ValidMessage_Success(t *testing.T) {
 
 	broker := NewTestBroker()
 	broker.SetRegisteredTaskNames([]string{"test_task"})
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	err := broker.consumeOne(makeDelivery(string(msgText), "msg-id", "pop-receipt"), &mockTaskProcessor{})
 	assert.NoError(t, err)
@@ -125,15 +89,15 @@ func TestConsumeOne_ValidMessage_Success(t *testing.T) {
 
 func TestConsumeOne_InvalidJSON(t *testing.T) {
 	deleted := false
-	client := &mockQueueClient{
-		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+	client := &MockClient{
+		DeleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
 			deleted = true
 			return azqueue.DeleteMessageResponse{}, nil
 		},
 	}
 
 	broker := NewTestBroker()
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	err := broker.consumeOne(makeDelivery("not valid json", "msg-id", "pop-receipt"), nil)
 	assert.Error(t, err)
@@ -142,8 +106,8 @@ func TestConsumeOne_InvalidJSON(t *testing.T) {
 
 func TestConsumeOne_UnregisteredTask(t *testing.T) {
 	deleted := false
-	client := &mockQueueClient{
-		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+	client := &MockClient{
+		DeleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
 			deleted = true
 			return azqueue.DeleteMessageResponse{}, nil
 		},
@@ -153,7 +117,7 @@ func TestConsumeOne_UnregisteredTask(t *testing.T) {
 	msgText, _ := json.Marshal(sig)
 
 	broker := NewTestBroker()
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	err := broker.consumeOne(makeDelivery(string(msgText), "msg-id", "pop-receipt"), nil)
 	assert.ErrorContains(t, err, "is not registered")
@@ -162,8 +126,8 @@ func TestConsumeOne_UnregisteredTask(t *testing.T) {
 
 func TestConsumeOne_IgnoreWhenNotRegistered(t *testing.T) {
 	deleted := false
-	client := &mockQueueClient{
-		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+	client := &MockClient{
+		DeleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
 			deleted = true
 			return azqueue.DeleteMessageResponse{}, nil
 		},
@@ -173,7 +137,7 @@ func TestConsumeOne_IgnoreWhenNotRegistered(t *testing.T) {
 	msgText, _ := json.Marshal(sig)
 
 	broker := NewTestBroker()
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	err := broker.consumeOne(makeDelivery(string(msgText), "msg-id", "pop-receipt"), nil)
 	assert.ErrorContains(t, err, "is not registered")
@@ -182,8 +146,8 @@ func TestConsumeOne_IgnoreWhenNotRegistered(t *testing.T) {
 
 func TestConsumeOne_StopTaskDeletion(t *testing.T) {
 	deleted := false
-	client := &mockQueueClient{
-		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+	client := &MockClient{
+		DeleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
 			deleted = true
 			return azqueue.DeleteMessageResponse{}, nil
 		},
@@ -200,7 +164,7 @@ func TestConsumeOne_StopTaskDeletion(t *testing.T) {
 
 	broker := NewTestBroker()
 	broker.SetRegisteredTaskNames([]string{"test_task"})
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	err := broker.consumeOne(makeDelivery(string(msgText), "msg-id", "pop-receipt"), tp)
 	assert.NoError(t, err)
@@ -212,8 +176,8 @@ func TestPublish_NoDelay(t *testing.T) {
 	var capturedOpts *azqueue.EnqueueMessageOptions
 	msgID := "msg-id"
 
-	client := &mockQueueClient{
-		enqueueFunc: func(_ context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+	client := &MockClient{
+		EnqueueFunc: func(_ context.Context, content string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
 			capturedContent = content
 			capturedOpts = opts
 			return azqueue.EnqueueMessagesResponse{
@@ -223,7 +187,7 @@ func TestPublish_NoDelay(t *testing.T) {
 	}
 
 	broker := NewTestBroker()
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	sig := &tasks.Signature{Name: "test_task", UUID: "abc123"}
 	err := broker.Publish(context.Background(), sig)
@@ -239,8 +203,8 @@ func TestPublish_TTL(t *testing.T) {
 	var capturedOpts *azqueue.EnqueueMessageOptions
 	msgID := "msg-id"
 
-	client := &mockQueueClient{
-		enqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+	client := &MockClient{
+		EnqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
 			capturedOpts = opts
 			return azqueue.EnqueueMessagesResponse{
 				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
@@ -250,7 +214,7 @@ func TestPublish_TTL(t *testing.T) {
 
 	broker := NewTestBroker()
 	broker.cfg.TTL = time.Hour
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	sig := &tasks.Signature{Name: "test_task", UUID: "abc123"}
 	err := broker.Publish(context.Background(), sig)
@@ -262,8 +226,8 @@ func TestPublish_WithDelay(t *testing.T) {
 	var capturedOpts *azqueue.EnqueueMessageOptions
 	msgID := "msg-id"
 
-	client := &mockQueueClient{
-		enqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+	client := &MockClient{
+		EnqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
 			capturedOpts = opts
 			return azqueue.EnqueueMessagesResponse{
 				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
@@ -273,7 +237,7 @@ func TestPublish_WithDelay(t *testing.T) {
 
 	broker := NewTestBroker()
 	broker.cfg.TTL = time.Hour
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	sig := &tasks.Signature{Name: "test_task", UUID: "abc123", Delay: 30 * time.Second}
 	err := broker.Publish(context.Background(), sig)
@@ -285,8 +249,8 @@ func TestPublish_DelayExceedsMax(t *testing.T) {
 	var capturedOpts *azqueue.EnqueueMessageOptions
 	msgID := "msg-id"
 
-	client := &mockQueueClient{
-		enqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+	client := &MockClient{
+		EnqueueFunc: func(_ context.Context, _ string, opts *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
 			capturedOpts = opts
 			return azqueue.EnqueueMessagesResponse{
 				Messages: []*azqueue.EnqueuedMessage{{MessageID: &msgID}},
@@ -296,7 +260,7 @@ func TestPublish_DelayExceedsMax(t *testing.T) {
 
 	broker := NewTestBroker()
 	broker.cfg.TTL = time.Hour
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	sig := &tasks.Signature{Name: "test_task", UUID: "abc123", Delay: maxDelay + time.Second}
 	err := broker.Publish(context.Background(), sig)
@@ -305,14 +269,14 @@ func TestPublish_DelayExceedsMax(t *testing.T) {
 }
 
 func TestPublish_EnqueueError(t *testing.T) {
-	client := &mockQueueClient{
-		enqueueFunc: func(_ context.Context, _ string, _ *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
+	client := &MockClient{
+		EnqueueFunc: func(_ context.Context, _ string, _ *azqueue.EnqueueMessageOptions) (azqueue.EnqueueMessagesResponse, error) {
 			return azqueue.EnqueueMessagesResponse{}, fmt.Errorf("network error")
 		},
 	}
 
 	broker := NewTestBroker()
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	sig := &tasks.Signature{Name: "test_task", UUID: "abc123"}
 	err := broker.Publish(context.Background(), sig)
@@ -325,8 +289,8 @@ func TestReceiveMessage(t *testing.T) {
 	msgText := "hello"
 
 	var capturedOpts *azqueue.DequeueMessageOptions
-	client := &mockQueueClient{
-		dequeueFunc: func(_ context.Context, opts *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
+	client := &MockClient{
+		DequeueFunc: func(_ context.Context, opts *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
 			capturedOpts = opts
 			return azqueue.DequeueMessagesResponse{
 				Messages: []*azqueue.DequeuedMessage{{
@@ -340,7 +304,7 @@ func TestReceiveMessage(t *testing.T) {
 
 	broker := NewTestBroker()
 	broker.cfg.VisibilityTimeout = 30 * time.Second
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	result, err := broker.receiveMessage()
 	assert.NoError(t, err)
@@ -350,14 +314,14 @@ func TestReceiveMessage(t *testing.T) {
 }
 
 func TestReceiveMessage_Error(t *testing.T) {
-	client := &mockQueueClient{
-		dequeueFunc: func(_ context.Context, _ *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
+	client := &MockClient{
+		DequeueFunc: func(_ context.Context, _ *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
 			return azqueue.DequeueMessagesResponse{}, fmt.Errorf("dequeue error")
 		},
 	}
 
 	broker := NewTestBroker()
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	_, err := broker.receiveMessage()
 	assert.ErrorContains(t, err, "dequeue error")
@@ -365,8 +329,8 @@ func TestReceiveMessage_Error(t *testing.T) {
 
 func TestDeleteOne(t *testing.T) {
 	var deletedID, deletedReceipt string
-	client := &mockQueueClient{
-		deleteFunc: func(_ context.Context, messageID, popReceipt string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+	client := &MockClient{
+		DeleteFunc: func(_ context.Context, messageID, popReceipt string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
 			deletedID = messageID
 			deletedReceipt = popReceipt
 			return azqueue.DeleteMessageResponse{}, nil
@@ -374,7 +338,7 @@ func TestDeleteOne(t *testing.T) {
 	}
 
 	broker := NewTestBroker()
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	msgID := "msg-id"
 	popReceipt := "pop-receipt"
@@ -385,14 +349,14 @@ func TestDeleteOne(t *testing.T) {
 }
 
 func TestDeleteOne_Error(t *testing.T) {
-	client := &mockQueueClient{
-		deleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+	client := &MockClient{
+		DeleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
 			return azqueue.DeleteMessageResponse{}, fmt.Errorf("delete error")
 		},
 	}
 
 	broker := NewTestBroker()
-	broker.SetQueueClientFactoryForTest(func(string) queueClient { return client })
+	broker.SetMockClientForTest(client)
 
 	msgID := "msg-id"
 	popReceipt := "pop-receipt"

--- a/v1/brokers/azure/storage_queue_test.go
+++ b/v1/brokers/azure/storage_queue_test.go
@@ -1,0 +1,48 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+	"github.com/RichardKnop/machinery/v1/brokers/azure"
+	"github.com/RichardKnop/machinery/v1/brokers/iface"
+	"github.com/RichardKnop/machinery/v1/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew_ImplementsInterfaces(t *testing.T) {
+	t.Parallel()
+
+	cnf := &config.Config{
+		DefaultQueue: "test_queue",
+		Azure:        &config.AzureConfig{},
+	}
+	broker := azure.NewTestBroker()
+	assert.IsType(t, broker, azure.New(cnf))
+
+	// Compile-time check that *Broker satisfies RetrySameMessage.
+	var asRetry iface.RetrySameMessage
+	asRetry = broker
+	assert.NotNil(t, asRetry)
+}
+
+func TestInitializePool(t *testing.T) {
+	broker := azure.NewTestBroker()
+	concurrency := 9
+	pool := make(chan struct{}, concurrency)
+	broker.InitializePoolForTest(pool, concurrency)
+	assert.Len(t, pool, concurrency)
+}
+
+func TestStopReceiving(t *testing.T) {
+	broker := azure.NewTestBroker()
+	go broker.StopReceivingForTest()
+	stopReceivingChan := broker.GetStopReceivingChanForTest()
+	assert.NotNil(t, <-stopReceivingChan)
+}
+
+func TestConsumeOne_EmptyMessages(t *testing.T) {
+	broker := azure.NewTestBroker()
+	err := broker.ConsumeOneForTest(azqueue.DequeueMessagesResponse{}, nil)
+	assert.ErrorContains(t, err, "received empty message")
+}

--- a/v1/brokers/azure/storage_queue_test.go
+++ b/v1/brokers/azure/storage_queue_test.go
@@ -1,13 +1,19 @@
 package azure_test
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+	machinery "github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/brokers/azure"
 	"github.com/RichardKnop/machinery/v1/brokers/iface"
+	"github.com/RichardKnop/machinery/v1/common"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew_ImplementsInterfaces(t *testing.T) {
@@ -45,4 +51,96 @@ func TestConsumeOne_EmptyMessages(t *testing.T) {
 	broker := azure.NewTestBroker()
 	err := broker.ConsumeOneForTest(azqueue.DequeueMessagesResponse{}, nil)
 	assert.ErrorContains(t, err, "received empty message")
+}
+
+type testV2Token struct{ returnFn func() }
+
+func (t *testV2Token) Return() { t.returnFn() }
+
+type testV2Pool struct {
+	iface.ResizeablePool
+	tokenCh chan iface.Token
+}
+
+func (tp *testV2Pool) PoolWithToken() <-chan iface.Token { return tp.tokenCh }
+
+func newTestV2Pool(capacity int) *testV2Pool {
+	p, _ := common.NewResizablePool(capacity)
+	tp := &testV2Pool{
+		ResizeablePool: p,
+		tokenCh:        make(chan iface.Token),
+	}
+	go func() {
+		for {
+			<-p.Pool()
+			tp.tokenCh <- &testV2Token{returnFn: p.Return}
+		}
+	}()
+	return tp
+}
+
+func testStartConsumingProcessesTask(t *testing.T, pool iface.ResizeablePool) {
+	t.Helper()
+
+	const taskName = "sc-test-task"
+	taskMsg := `{"UUID":"sc-test-uuid","Name":"sc-test-task"}`
+	msgID := "sc-msg-id"
+	popReceipt := "sc-pop-receipt"
+
+	var dequeueCount int32
+	client := &azure.MockClient{
+		DequeueFunc: func(_ context.Context, _ *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
+			if atomic.AddInt32(&dequeueCount, 1) == 1 {
+				return azqueue.DequeueMessagesResponse{
+					Messages: []*azqueue.DequeuedMessage{{
+						MessageID:   &msgID,
+						PopReceipt:  &popReceipt,
+						MessageText: &taskMsg,
+					}},
+				}, nil
+			}
+			return azqueue.DequeueMessagesResponse{}, nil
+		},
+		DeleteFunc: func(_ context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+			return azqueue.DeleteMessageResponse{}, nil
+		},
+	}
+
+	broker := azure.NewTestBroker()
+	broker.SetRegisteredTaskNames([]string{taskName})
+	broker.SetMockClientForTest(client)
+
+	server, err := machinery.NewServer(&config.Config{
+		Broker:        "eager",
+		DefaultQueue:  "test_queue",
+		ResultBackend: "eager",
+	})
+	require.NoError(t, err)
+
+	output := make(chan struct{}, 10)
+	err = server.RegisterTask(taskName, func(_ context.Context) error {
+		output <- struct{}{}
+		return nil
+	})
+	require.NoError(t, err)
+
+	wk := server.NewWorker("sc-worker", 0)
+
+	go broker.StartConsuming("sc-tag", pool, wk) //nolint:errcheck
+
+	select {
+	case <-output:
+		broker.StopConsuming()
+	case <-time.After(5 * time.Second):
+		t.Fatal("task was not processed within timeout")
+	}
+}
+
+func TestStartConsuming_V1_ProcessesTask(t *testing.T) {
+	pool, _ := common.NewResizablePool(1)
+	testStartConsumingProcessesTask(t, pool)
+}
+
+func TestStartConsuming_V2_ProcessesTask(t *testing.T) {
+	testStartConsumingProcessesTask(t, newTestV2Pool(1))
 }

--- a/v1/brokers/azure/storage_queue_test.go
+++ b/v1/brokers/azure/storage_queue_test.go
@@ -123,7 +123,7 @@ func testStartConsumingProcessesTask(t *testing.T, pool iface.ResizeablePool) {
 
 	wk := server.NewWorker("sc-worker", 0)
 
-	go broker.StartConsuming("sc-tag", pool, wk) //nolint:errcheck
+	go broker.StartConsuming("sc-tag", pool, wk)
 
 	select {
 	case <-output:

--- a/v1/brokers/azure/storage_queue_test.go
+++ b/v1/brokers/azure/storage_queue_test.go
@@ -83,9 +83,6 @@ func testStartConsumingProcessesTask(t *testing.T, pool iface.ResizeablePool) {
 	t.Helper()
 
 	const taskName = "sc-test-task"
-	taskMsg := `{"UUID":"sc-test-uuid","Name":"sc-test-task"}`
-	msgID := "sc-msg-id"
-	popReceipt := "sc-pop-receipt"
 
 	var dequeueCount int32
 	client := &azure.MockClient{
@@ -93,9 +90,9 @@ func testStartConsumingProcessesTask(t *testing.T, pool iface.ResizeablePool) {
 			if atomic.AddInt32(&dequeueCount, 1) == 1 {
 				return azqueue.DequeueMessagesResponse{
 					Messages: []*azqueue.DequeuedMessage{{
-						MessageID:   &msgID,
-						PopReceipt:  &popReceipt,
-						MessageText: &taskMsg,
+						MessageID:   new("sc-msg-id"),
+						PopReceipt:  new("sc-pop-receipt"),
+						MessageText: new(`{"UUID":"sc-test-uuid","Name":"sc-test-task"}`),
 					}},
 				}, nil
 			}


### PR DESCRIPTION
Adds some simple test coverage for our Azure Storage Queues broker (+ very minor changes to the broker itself to support testing). Adding this in preparation for DLQs to reduce the risk that anything regresses as part of that change.

Mostly generated by asking Claude to produce equivalent test coverage to what we have now for SQS, plus a few additional cases.

Written (almost) entirely by Claude; reviewed by me