### PR TITLE
fix: suppress decode errors in brokers

### DIFF
--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -266,11 +266,7 @@ func (b *Broker) consumeOne(delivery azqueue.DequeueMessagesResponse, taskProces
 	decoder.UseNumber()
 	if err := decoder.Decode(sig); err != nil {
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
-		// if the unmarshal fails, remove the delivery from the queue
-		if delErr := b.deleteOne(msg); delErr != nil {
-			log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, delErr)
-		}
-		return err
+		return nil
 	}
 
 	sig.ReceivedAt = time.Now()

--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -266,6 +266,10 @@ func (b *Broker) consumeOne(delivery azqueue.DequeueMessagesResponse, taskProces
 	decoder.UseNumber()
 	if err := decoder.Decode(sig); err != nil {
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
+		if delErr := b.deleteOne(msg); delErr != nil {
+			log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, delErr)
+		}
+		// Never return an error — doing so would kill the consumer loop.
 		return nil
 	}
 

--- a/v1/brokers/azure/storage_queue_internal_test.go
+++ b/v1/brokers/azure/storage_queue_internal_test.go
@@ -100,8 +100,8 @@ func TestConsumeOne_InvalidJSON(t *testing.T) {
 	broker.SetMockClientForTest(client)
 
 	err := broker.consumeOne(makeDelivery("not valid json", "msg-id", "pop-receipt"), nil)
-	assert.Error(t, err)
-	assert.True(t, deleted)
+	assert.NoError(t, err)
+	assert.False(t, deleted)
 }
 
 func TestConsumeOne_UnregisteredTask(t *testing.T) {

--- a/v1/brokers/azure/storage_queue_internal_test.go
+++ b/v1/brokers/azure/storage_queue_internal_test.go
@@ -101,7 +101,7 @@ func TestConsumeOne_InvalidJSON(t *testing.T) {
 
 	err := broker.consumeOne(makeDelivery("not valid json", "msg-id", "pop-receipt"), nil)
 	assert.NoError(t, err)
-	assert.False(t, deleted)
+	assert.True(t, deleted)
 }
 
 func TestConsumeOne_UnregisteredTask(t *testing.T) {

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -299,7 +299,7 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 		if rc := delivery.Messages[0].Attributes[awssqs.MessageSystemAttributeNameApproximateReceiveCount]; rc != nil {
 			if count, err := strconv.ParseInt(*rc, 10, 64); err == nil && count >= maxReceiveCountBeforeDelete {
 				if delErr := b.deleteOne(delivery); delErr != nil {
-					log.ERROR.Printf("deleting the delivery. delivery is %v, Error=%s", delivery, delErr)
+					log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, delErr)
 				}
 			}
 		}
@@ -378,7 +378,7 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	}
 	// Delete message after successfully consuming and processing the message
 	if err = b.deleteOne(delivery); err != nil {
-		log.ERROR.Printf("deleting the delivery. delivery is %v, Error=%s", delivery, err)
+		log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, err)
 	}
 	return err
 }

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -292,11 +292,7 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	decoder.UseNumber()
 	if err := decoder.Decode(sig); err != nil {
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
-		// if the unmarshal fails, remove the delivery from the queue
-		if delErr := b.deleteOne(delivery); delErr != nil {
-			log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, delErr)
-		}
-		return err
+		return nil
 	}
 
 	sig.ReceivedAt = time.Now()

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -30,8 +30,7 @@ const (
 	logSQSReceiveSampleRate    = 0.0001           // 0.01% of messages received from SQS will be logged
 	logSQSEmptySampleRate      = 0.00001          // 0.001% of empty received calls to SQS will be logged
 	// maxReceiveCountBeforeDelete is the SQS ApproximateReceiveCount at which an
-	// undecodable message is deleted. This acts as a fallback DLQ for queues that
-	// don't have one configured. Set above our standard DLQ threshold (10) so
+	// undecodable message is deleted. Set above our standard DLQ threshold (10) so
 	// that queues with a DLQ still route there first.
 	maxReceiveCountBeforeDelete = 15
 )
@@ -300,7 +299,7 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 		if rc := delivery.Messages[0].Attributes[awssqs.MessageSystemAttributeNameApproximateReceiveCount]; rc != nil {
 			if count, err := strconv.ParseInt(*rc, 10, 64); err == nil && count >= maxReceiveCountBeforeDelete {
 				if delErr := b.deleteOne(delivery); delErr != nil {
-					log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, delErr)
+					log.ERROR.Printf("deleting the delivery. delivery is %v, Error=%s", delivery, delErr)
 				}
 			}
 		}
@@ -379,7 +378,7 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	}
 	// Delete message after successfully consuming and processing the message
 	if err = b.deleteOne(delivery); err != nil {
-		log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, err)
+		log.ERROR.Printf("deleting the delivery. delivery is %v, Error=%s", delivery, err)
 	}
 	return err
 }

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -29,6 +29,11 @@ const (
 	maxAWSSQSVisibilityTimeout = time.Hour * 12   // Max supported SQS visibility timeout is 12 hours: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibility.html
 	logSQSReceiveSampleRate    = 0.0001           // 0.01% of messages received from SQS will be logged
 	logSQSEmptySampleRate      = 0.00001          // 0.001% of empty received calls to SQS will be logged
+	// maxReceiveCountBeforeDelete is the SQS ApproximateReceiveCount at which an
+	// undecodable message is deleted. This acts as a fallback DLQ for queues that
+	// don't have one configured. Set above our standard DLQ threshold (10) so
+	// that queues with a DLQ still route there first.
+	maxReceiveCountBeforeDelete = 15
 )
 
 // Broker represents a AWS SQS broker
@@ -292,6 +297,13 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	decoder.UseNumber()
 	if err := decoder.Decode(sig); err != nil {
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
+		if rc := delivery.Messages[0].Attributes[awssqs.MessageSystemAttributeNameApproximateReceiveCount]; rc != nil {
+			if count, err := strconv.ParseInt(*rc, 10, 64); err == nil && count >= maxReceiveCountBeforeDelete {
+				if delErr := b.deleteOne(delivery); delErr != nil {
+					log.ERROR.Printf("error when deleting the delivery. delivery is %v, Error=%s", delivery, delErr)
+				}
+			}
+		}
 		// Never return an error — doing so would kill the consumer loop.
 		return nil
 	}

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -292,6 +292,7 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 	decoder.UseNumber()
 	if err := decoder.Decode(sig); err != nil {
 		log.ERROR.Printf("unmarshal error. the delivery is %v", delivery)
+		// Never return an error — doing so would kill the consumer loop.
 		return nil
 	}
 

--- a/v1/brokers/sqs/sqs_test.go
+++ b/v1/brokers/sqs/sqs_test.go
@@ -155,21 +155,36 @@ func (f *deleteTrackingSQS) DeleteMessage(*awssqs.DeleteMessageInput) (*awssqs.D
 	return &awssqs.DeleteMessageOutput{}, nil
 }
 
-func TestConsumeOne_InvalidJSON(t *testing.T) {
+func invalidJSONMessage(receiveCount string) *awssqs.ReceiveMessageOutput {
+	msg := &awssqs.Message{
+		MessageId:     aws.String("msg-id"),
+		ReceiptHandle: aws.String("receipt"),
+		Body:          aws.String("not valid json"),
+	}
+	if receiveCount != "" {
+		msg.Attributes = map[string]*string{
+			awssqs.MessageSystemAttributeNameApproximateReceiveCount: aws.String(receiveCount),
+		}
+	}
+	return &awssqs.ReceiveMessageOutput{Messages: []*awssqs.Message{msg}}
+}
+
+func TestConsumeOne_InvalidJSON_BelowThreshold(t *testing.T) {
 	fakeSvc := &deleteTrackingSQS{}
 	broker := sqs.NewTestBrokerWithService(fakeSvc)
 
-	output := &awssqs.ReceiveMessageOutput{
-		Messages: []*awssqs.Message{{
-			MessageId:     aws.String("msg-id"),
-			ReceiptHandle: aws.String("receipt"),
-			Body:          aws.String("not valid json"),
-		}},
-	}
-
-	err := broker.ConsumeOneForTest(output, nil)
+	err := broker.ConsumeOneForTest(invalidJSONMessage("14"), nil)
 	assert.Nil(t, err)
 	assert.False(t, fakeSvc.deleted)
+}
+
+func TestConsumeOne_InvalidJSON_AtThreshold(t *testing.T) {
+	fakeSvc := &deleteTrackingSQS{}
+	broker := sqs.NewTestBrokerWithService(fakeSvc)
+
+	err := broker.ConsumeOneForTest(invalidJSONMessage("15"), nil)
+	assert.Nil(t, err)
+	assert.True(t, fakeSvc.deleted)
 }
 
 func TestPrivateFunc_initializePool(t *testing.T) {

--- a/v1/brokers/sqs/sqs_test.go
+++ b/v1/brokers/sqs/sqs_test.go
@@ -142,7 +142,34 @@ func TestPrivateFunc_consumeOne(t *testing.T) {
 		},
 	}
 	err = broker.ConsumeOneForTest(&outputCopy, wk)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
+}
+
+type deleteTrackingSQS struct {
+	sqs.FakeSQS
+	deleted bool
+}
+
+func (f *deleteTrackingSQS) DeleteMessage(*awssqs.DeleteMessageInput) (*awssqs.DeleteMessageOutput, error) {
+	f.deleted = true
+	return &awssqs.DeleteMessageOutput{}, nil
+}
+
+func TestConsumeOne_InvalidJSON(t *testing.T) {
+	fakeSvc := &deleteTrackingSQS{}
+	broker := sqs.NewTestBrokerWithService(fakeSvc)
+
+	output := &awssqs.ReceiveMessageOutput{
+		Messages: []*awssqs.Message{{
+			MessageId:     aws.String("msg-id"),
+			ReceiptHandle: aws.String("receipt"),
+			Body:          aws.String("not valid json"),
+		}},
+	}
+
+	err := broker.ConsumeOneForTest(output, nil)
+	assert.Nil(t, err)
+	assert.False(t, fakeSvc.deleted)
 }
 
 func TestPrivateFunc_initializePool(t *testing.T) {


### PR DESCRIPTION
Follow up to https://github.com/sublime-security/machinery/pull/51#discussion_r3198178491

On JSON decode failure, don't propagate the error back up. SQS broker returns `nil` so we DLQ the message and can debug from there (and explicitly deletes above a configurable attempt count to handle deployments/queues with no DLQ configured); Azure Storage Queue broker deletes, since there's no built-in DLQ support and reprocessing would just spin if we didn't.