### PR TITLE
[Bug] eager backend: guard groups/tasks maps with a single mutex

### DIFF
--- a/v1/backends/eager/eager.go
+++ b/v1/backends/eager/eager.go
@@ -42,12 +42,17 @@ func (e ErrTasknotFound) Error() string {
 	return fmt.Sprintf("Task not found: %v", e.taskUUID)
 }
 
-// Backend represents an "eager" in-memory result backend
+// Backend represents an "eager" in-memory result backend.
+//
+// All methods are safe for concurrent use. A single sync.Mutex guards both the groups and tasks
+// maps. This is intentionally coarse: the eager backend is intended for tests and local development,
+// where contention is low and a single lock keeps the invariant ("one caller at a time touches
+// internal state") easy to reason about.
 type Backend struct {
 	common.Backend
-	groups     map[string][]string
-	tasks      map[string][]byte
-	stateMutex sync.Mutex
+	mu     sync.Mutex
+	groups map[string][]string
+	tasks  map[string][]byte
 }
 
 // New creates EagerBackend instance
@@ -65,12 +70,17 @@ func (b *Backend) InitGroup(groupUUID string, taskUUIDs []string) error {
 	// copy every task
 	tasks = append(tasks, taskUUIDs...)
 
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.groups[groupUUID] = tasks
 	return nil
 }
 
 // GroupCompleted returns true if all tasks in a group finished
 func (b *Backend) GroupCompleted(groupUUID string, groupTaskCount int) (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	tasks, ok := b.groups[groupUUID]
 	if !ok {
 		return false, NewErrGroupNotFound(groupUUID)
@@ -78,7 +88,7 @@ func (b *Backend) GroupCompleted(groupUUID string, groupTaskCount int) (bool, er
 
 	var countSuccessTasks = 0
 	for _, v := range tasks {
-		t, err := b.GetState(v)
+		t, err := b.getStateLocked(v)
 		if err != nil {
 			return false, err
 		}
@@ -93,6 +103,9 @@ func (b *Backend) GroupCompleted(groupUUID string, groupTaskCount int) (bool, er
 
 // GroupTaskStates returns states of all tasks in the group
 func (b *Backend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*tasks.TaskState, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	taskUUIDs, ok := b.groups[groupUUID]
 	if !ok {
 		return nil, NewErrGroupNotFound(groupUUID)
@@ -100,7 +113,7 @@ func (b *Backend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*task
 
 	ret := make([]*tasks.TaskState, 0, groupTaskCount)
 	for _, taskUUID := range taskUUIDs {
-		t, err := b.GetState(taskUUID)
+		t, err := b.getStateLocked(taskUUID)
 		if err != nil {
 			return nil, err
 		}
@@ -157,6 +170,13 @@ func (b *Backend) SetStateFailure(signature *tasks.Signature, err string) error 
 
 // GetState returns the latest task state
 func (b *Backend) GetState(taskUUID string) (*tasks.TaskState, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.getStateLocked(taskUUID)
+}
+
+// getStateLocked is the unlocked variant of GetState. Caller must hold b.mu.
+func (b *Backend) getStateLocked(taskUUID string) (*tasks.TaskState, error) {
 	tasktStateBytes, ok := b.tasks[taskUUID]
 	if !ok {
 		return nil, NewErrTasknotFound(taskUUID)
@@ -174,6 +194,9 @@ func (b *Backend) GetState(taskUUID string) (*tasks.TaskState, error) {
 
 // PurgeState deletes stored task state
 func (b *Backend) PurgeState(taskUUID string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	_, ok := b.tasks[taskUUID]
 	if !ok {
 		return NewErrTasknotFound(taskUUID)
@@ -185,6 +208,9 @@ func (b *Backend) PurgeState(taskUUID string) error {
 
 // PurgeGroupMeta deletes stored group meta data
 func (b *Backend) PurgeGroupMeta(groupUUID string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	_, ok := b.groups[groupUUID]
 	if !ok {
 		return NewErrGroupNotFound(groupUUID)
@@ -196,13 +222,13 @@ func (b *Backend) PurgeGroupMeta(groupUUID string) error {
 
 func (b *Backend) updateState(s *tasks.TaskState) error {
 	// simulate the behavior of json marshal/unmarshal
-	b.stateMutex.Lock()
-	defer b.stateMutex.Unlock()
 	msg, err := json.Marshal(s)
 	if err != nil {
 		return fmt.Errorf("Marshal task state error: %v", err)
 	}
 
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.tasks[s.TaskUUID] = msg
 	return nil
 }

--- a/v1/backends/eager/eager_test.go
+++ b/v1/backends/eager/eager_test.go
@@ -2,6 +2,8 @@ package eager_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/RichardKnop/machinery/v1/backends/eager"
@@ -339,4 +341,57 @@ func (s *EagerBackendTestSuite) getTaskSignature(taskUUID string) *tasks.Signatu
 
 func TestEagerBackendMain(t *testing.T) {
 	suite.Run(t, &EagerBackendTestSuite{})
+}
+
+// TestEagerBackend_ConcurrentAccess exercises concurrent reads and writes against the eager
+// backend's internal maps. Prior to introducing a single mutex covering all map accesses, a
+// concurrent caller mix like this would deterministically trigger Go's "concurrent map read and
+// map write" fatal under -race (and frequently without). The test runs all operations the
+// backend exposes — SetState*, GetState, InitGroup, GroupCompleted, GroupTaskStates, PurgeState,
+// PurgeGroupMeta — so that any unprotected map access in any method is exercised.
+func TestEagerBackend_ConcurrentAccess(t *testing.T) {
+	backend := eager.New()
+
+	const numGoroutines = 50
+	const numIterations = 200
+
+	// Seed some baseline state so the readers have non-empty data to scan.
+	for i := range numGoroutines {
+		sig := &tasks.Signature{UUID: fmt.Sprintf("seed-%d", i)}
+		if err := backend.SetStatePending(sig); err != nil {
+			t.Fatalf("seed SetStatePending: %v", err)
+		}
+	}
+	if err := backend.InitGroup("seed-group", []string{"seed-0", "seed-1", "seed-2"}); err != nil {
+		t.Fatalf("seed InitGroup: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for g := range numGoroutines {
+		wg.Go(func() {
+			for i := range numIterations {
+				uuid := fmt.Sprintf("task-%d-%d", g, i)
+				sig := &tasks.Signature{UUID: uuid}
+
+				// Writers: cycle through the SetState* surface.
+				_ = backend.SetStatePending(sig)
+				_ = backend.SetStateReceived(sig)
+				_ = backend.SetStateStarted(sig)
+				_ = backend.SetStateSuccess(sig, nil)
+
+				// Readers: GetState, group-state surfaces.
+				_, _ = backend.GetState(uuid)
+				_, _ = backend.GetState(fmt.Sprintf("seed-%d", g))
+				_, _ = backend.GroupCompleted("seed-group", 3)
+				_, _ = backend.GroupTaskStates("seed-group", 3)
+
+				// Group writers + purge: exercise the groups-map and tasks-map mutation paths.
+				groupID := fmt.Sprintf("group-%d-%d", g, i)
+				_ = backend.InitGroup(groupID, []string{uuid})
+				_ = backend.PurgeGroupMeta(groupID)
+				_ = backend.PurgeState(uuid)
+			}
+		})
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
- The v1 eager backend's `groups` and `tasks` maps were read without holding any lock — `updateState` was the only place that acquired `stateMutex`, and only while writing `tasks`. Concurrent callers can trip Go's "concurrent map read and map write" fatal.
- Replaces `stateMutex` with a single `sync.Mutex` (`mu`) that guards both maps across every public method, and introduces `getStateLocked` so `GroupCompleted`/`GroupTaskStates` can re-read `tasks` without re-acquiring the lock.
- A coarse single mutex is intentional: the eager backend is for tests and local development, contention is low, and one lock keeps the "single caller at a time touches internal state" invariant easy to reason about.

This is the same root cause reported upstream as RichardKnop/machinery#737 (PR #740). Upstream's fix uses two `sync.RWMutex` (one per map). Ours is simpler and also catches the v1 `PurgeGroupMeta` case that upstream PR #740 missed.

## v2 status
The same bug exists in `v2/backends/eager/eager.go` but is not addressed here. The v2 module has a pre-existing build break (`v2/config/config.go:65` references `MongoDBConfig`, which was deleted in commit `8617130` "Drop mongo support" #23 and never replaced). CI's `go list ./...` runs from the root module and doesn't descend into v2, so v2 is effectively unmaintained dead code in this fork. The v2 race-fix would need to come with a v2 build fix; leaving that as a separate decision.

## How did you validate this change
Added `TestEagerBackend_ConcurrentAccess` (`v1/backends/eager/eager_test.go`) — spawns 50 goroutines x 200 iterations and exercises every public surface: `SetState{Pending,Received,Started,Success}`, `GetState`, `InitGroup`, `GroupCompleted`, `GroupTaskStates`, `PurgeState`, `PurgeGroupMeta`. Without the mutex changes this test deterministically trips `go test -race`; with them it passes cleanly.

- Assisted by Claude 🤖