### PR TITLE
fix: queue client cancellation/timeouts

### DIFF
--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -24,6 +24,10 @@ const (
 	// message is deleted. Set above the default DLQ threshold (10) so that
 	// queues with a DLQ still route there first.
 	decodeFailureDeleteThreshold int64 = 15
+	// lifecycleCallTimeout bounds post-receive calls (delete, DLQ, retry) so a wedged
+	// request can't pin a concurrency slot for the container's life and starve the pool.
+	// 30s clears the azcore retry budget (~9s) and stays under the visibility timeout.
+	lifecycleCallTimeout = 30 * time.Second
 )
 
 type queueClient interface {
@@ -45,6 +49,11 @@ type Broker struct {
 	dlqClient         queueClient   // nil ⇒ DLQ disabled
 	maxReceives       int64
 	dlqTTL            time.Duration
+
+	// consumeCtx is cancelled by StopConsuming so an in-flight DequeueMessage returns
+	// at once and shutdown stops pulling work it can't finish in the ~30s grace.
+	consumeCtx    context.Context
+	cancelConsume context.CancelFunc
 }
 
 // New creates new Broker instance
@@ -76,6 +85,7 @@ var badRequestErrRegex = regexp.MustCompile(`4\d\d`)
 func (b *Broker) StartConsuming(consumerTag string, concurrency iface.ResizeablePool, taskProcessor iface.TaskProcessor) (bool, error) {
 	b.Broker.StartConsuming(consumerTag, taskProcessor)
 
+	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
 	b.stopReceivingChan = make(chan int)
 	b.receivingWG.Add(1)
 
@@ -108,15 +118,16 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 						b.processingWG.Done()
 					}()
 				} else {
-					if err != nil {
+					if err != nil && b.consumeCtx.Err() == nil {
 						log.ERROR.Printf("Queue consume error on %s: %s", b.queueName, err)
 						if badRequestErrRegex.MatchString(err.Error()) {
 							time.Sleep(30 * time.Second)
 						}
-					} else {
+					} else if err == nil {
 						// No messages, prevent fast looping
 						time.Sleep(100 * time.Millisecond)
 					}
+					// On shutdown cancellation, skip the log; the next pass takes stopReceivingChan.
 					token.Return()
 				}
 			}
@@ -143,16 +154,16 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 				if err == nil && len(output.Messages) > 0 {
 					deliveries <- output
 				} else {
-					if err != nil {
+					if err != nil && b.consumeCtx.Err() == nil {
 						log.ERROR.Printf("Queue consume error on %s: %s", b.queueName, err)
 						if badRequestErrRegex.MatchString(err.Error()) {
 							time.Sleep(30 * time.Second)
 						}
-					} else {
+					} else if err == nil {
 						// No messages, prevent fast looping
 						time.Sleep(100 * time.Millisecond)
 					}
-					// return back to pool right away
+					// On shutdown cancellation, skip the log; the next pass takes stopReceivingChan.
 					concurrency.Return()
 				}
 			}
@@ -169,6 +180,11 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 // StopConsuming quits the loop
 func (b *Broker) StopConsuming() {
 	b.Broker.StopConsuming()
+
+	// Cancel before signalling stop so an in-flight DequeueMessage unblocks and the loop sees stopReceivingChan.
+	if b.cancelConsume != nil {
+		b.cancelConsume()
+	}
 
 	b.stopReceiving()
 
@@ -244,8 +260,11 @@ func (b *Broker) RetryMessage(signature *tasks.Signature) {
 
 	delayS := int32(signature.Delay.Seconds())
 
+	// On timeout the message redelivers on its existing visibility timeout rather than this backoff.
+	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
+	defer cancel()
 	_, err := b.newQueueClient(signature.RoutingKey).UpdateMessage(
-		context.Background(),
+		ctx,
 		signature.AzureMessageID,
 		signature.AzurePopReceipt,
 		signature.AzureMessageContent,
@@ -368,9 +387,12 @@ func (b *Broker) consumeOne(delivery azqueue.DequeueMessagesResponse, taskProces
 
 // dlqOne enqueues a message to the configured DLQ.
 func (b *Broker) dlqOne(msg *azqueue.DequeuedMessage) error {
+	// On timeout the message stays on the source queue and is retried.
+	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
+	defer cancel()
 	ttlSeconds := int32(b.dlqTTL.Seconds())
 	_, err := b.dlqClient.EnqueueMessage(
-		context.Background(),
+		ctx,
 		*msg.MessageText,
 		&azqueue.EnqueueMessageOptions{TimeToLive: &ttlSeconds},
 	)
@@ -379,7 +401,10 @@ func (b *Broker) dlqOne(msg *azqueue.DequeuedMessage) error {
 
 // deleteOne is a method delete a delivery from AWS SQS
 func (b *Broker) deleteOne(message *azqueue.DequeuedMessage) error {
-	_, err := b.newQueueClient(b.queueName).DeleteMessage(context.Background(), *message.MessageID, *message.PopReceipt, nil)
+	// On timeout the completed task's message redelivers after its visibility timeout — at-least-once tolerates it.
+	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
+	defer cancel()
+	_, err := b.newQueueClient(b.queueName).DeleteMessage(ctx, *message.MessageID, *message.PopReceipt, nil)
 	if err != nil {
 		return err
 	}
@@ -388,8 +413,13 @@ func (b *Broker) deleteOne(message *azqueue.DequeuedMessage) error {
 
 // receiveMessage is a method receives a message from specified queue url
 func (b *Broker) receiveMessage() (azqueue.DequeueMessagesResponse, error) {
+	// consumeCtx is nil only when receiveMessage is called outside StartConsuming (e.g. tests).
+	ctx := b.consumeCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	visibilityTimeoutS := int32(b.cfg.VisibilityTimeout.Seconds())
-	result, err := b.newQueueClient(b.queueName).DequeueMessage(context.Background(), &azqueue.DequeueMessageOptions{VisibilityTimeout: &visibilityTimeoutS})
+	result, err := b.newQueueClient(b.queueName).DequeueMessage(ctx, &azqueue.DequeueMessageOptions{VisibilityTimeout: &visibilityTimeoutS})
 	if err != nil {
 		return azqueue.DequeueMessagesResponse{}, err
 	}

--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -264,7 +264,7 @@ func (b *Broker) RetryMessage(signature *tasks.Signature) {
 
 	delayS := int32(signature.Delay.Seconds())
 
-	// On timeout the message redelivers on its existing visibility timeout rather than this backoff.
+	// If this call times out, the message redelivers on its existing visibility timeout rather than this backoff.
 	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
 	defer cancel()
 	_, err := b.newQueueClient(signature.RoutingKey).UpdateMessage(
@@ -391,7 +391,7 @@ func (b *Broker) consumeOne(delivery azqueue.DequeueMessagesResponse, taskProces
 
 // dlqOne enqueues a message to the configured DLQ.
 func (b *Broker) dlqOne(msg *azqueue.DequeuedMessage) error {
-	// On timeout the message stays on the source queue and is retried.
+	// If this call times out, the message stays on the source queue and is retried.
 	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
 	defer cancel()
 	ttlSeconds := int32(b.dlqTTL.Seconds())
@@ -405,7 +405,8 @@ func (b *Broker) dlqOne(msg *azqueue.DequeuedMessage) error {
 
 // deleteOne is a method delete a delivery from AWS SQS
 func (b *Broker) deleteOne(message *azqueue.DequeuedMessage) error {
-	// On timeout the completed task's message redelivers after its visibility timeout — at-least-once tolerates it.
+	// If this call times out, the completed task's message redelivers — callers must already
+	// tolerate reprocessing, since the queue doesn't guarantee exactly-once delivery.
 	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
 	defer cancel()
 	_, err := b.newQueueClient(b.queueName).DeleteMessage(ctx, *message.MessageID, *message.PopReceipt, nil)

--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -120,6 +120,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 						b.processingWG.Done()
 					}()
 				} else {
+					// A cancelled consumeCtx surfaces as a receive error, so b.consumeCtx.Err() != nil implies err != nil.
 					if err != nil && b.consumeCtx.Err() == nil {
 						log.ERROR.Printf("Queue consume error on %s: %s", b.queueName, err)
 						if badRequestErrRegex.MatchString(err.Error()) {

--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -59,6 +59,8 @@ type Broker struct {
 // New creates new Broker instance
 func New(cnf *config.Config) iface.Broker {
 	b := &Broker{Broker: common.NewBroker(cnf)}
+	// StartConsuming replaces this with a cancellable context.
+	b.consumeCtx = context.Background()
 	b.cfg = *cnf.Azure
 	b.queueName = cnf.DefaultQueue
 	b.newQueueClient = func(name string) queueClient {
@@ -154,6 +156,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 				if err == nil && len(output.Messages) > 0 {
 					deliveries <- output
 				} else {
+					// A cancelled consumeCtx surfaces as a receive error, so b.consumeCtx.Err() != nil implies err != nil.
 					if err != nil && b.consumeCtx.Err() == nil {
 						log.ERROR.Printf("Queue consume error on %s: %s", b.queueName, err)
 						if badRequestErrRegex.MatchString(err.Error()) {
@@ -413,13 +416,8 @@ func (b *Broker) deleteOne(message *azqueue.DequeuedMessage) error {
 
 // receiveMessage is a method receives a message from specified queue url
 func (b *Broker) receiveMessage() (azqueue.DequeueMessagesResponse, error) {
-	// consumeCtx is nil only when receiveMessage is called outside StartConsuming (e.g. tests).
-	ctx := b.consumeCtx
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	visibilityTimeoutS := int32(b.cfg.VisibilityTimeout.Seconds())
-	result, err := b.newQueueClient(b.queueName).DequeueMessage(ctx, &azqueue.DequeueMessageOptions{VisibilityTimeout: &visibilityTimeoutS})
+	result, err := b.newQueueClient(b.queueName).DequeueMessage(b.consumeCtx, &azqueue.DequeueMessageOptions{VisibilityTimeout: &visibilityTimeoutS})
 	if err != nil {
 		return azqueue.DequeueMessagesResponse{}, err
 	}

--- a/v1/brokers/azure/storage_queue.go
+++ b/v1/brokers/azure/storage_queue.go
@@ -28,6 +28,9 @@ const (
 	// request can't pin a concurrency slot for the container's life and starve the pool.
 	// 30s clears the azcore retry budget (~9s) and stays under the visibility timeout.
 	lifecycleCallTimeout = 30 * time.Second
+	// receiveCallTimeout bounds a wedged DequeueMessage so a hung receive can't hold a
+	// concurrency slot. Derived from consumeCtx, so shutdown still cancels it at once.
+	receiveCallTimeout = 30 * time.Second
 )
 
 type queueClient interface {
@@ -59,8 +62,8 @@ type Broker struct {
 // New creates new Broker instance
 func New(cnf *config.Config) iface.Broker {
 	b := &Broker{Broker: common.NewBroker(cnf)}
-	// StartConsuming replaces this with a cancellable context.
-	b.consumeCtx = context.Background()
+	// StartConsuming replaces this with the per-session cancellable context.
+	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
 	b.cfg = *cnf.Azure
 	b.queueName = cnf.DefaultQueue
 	b.newQueueClient = func(name string) queueClient {
@@ -88,6 +91,8 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 	b.Broker.StartConsuming(consumerTag, taskProcessor)
 
 	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
+	// Release the context on every return path; StopConsuming also cancels eagerly to unblock an in-flight receive.
+	defer b.cancelConsume()
 	b.stopReceivingChan = make(chan int)
 	b.receivingWG.Add(1)
 
@@ -107,6 +112,9 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 			case workerError := <-errorsChan:
 				return b.GetRetry(), workerError
 			case <-b.stopReceivingChan:
+				return false, nil
+			case <-b.consumeCtx.Done():
+				// Exit on cancellation alone, without relying on a stopReceivingChan signal.
 				return false, nil
 			case token := <-tokenPool:
 				output, err := b.receiveMessage()
@@ -130,7 +138,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 						// No messages, prevent fast looping
 						time.Sleep(100 * time.Millisecond)
 					}
-					// On shutdown cancellation, skip the log; the next pass takes stopReceivingChan.
+					// On shutdown cancellation, skip the log; the next pass takes the consumeCtx.Done() case.
 					token.Return()
 				}
 			}
@@ -152,6 +160,11 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 				close(deliveries)
 
 				return
+			case <-b.consumeCtx.Done():
+				// Exit on cancellation alone, without relying on a stopReceivingChan signal.
+				close(deliveries)
+
+				return
 			case <-pool:
 				output, err := b.receiveMessage()
 				if err == nil && len(output.Messages) > 0 {
@@ -167,7 +180,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 						// No messages, prevent fast looping
 						time.Sleep(100 * time.Millisecond)
 					}
-					// On shutdown cancellation, skip the log; the next pass takes stopReceivingChan.
+					// On shutdown cancellation, skip the log; the next pass takes the consumeCtx.Done() case.
 					concurrency.Return()
 				}
 			}
@@ -186,9 +199,7 @@ func (b *Broker) StopConsuming() {
 	b.Broker.StopConsuming()
 
 	// Cancel before signalling stop so an in-flight DequeueMessage unblocks and the loop sees stopReceivingChan.
-	if b.cancelConsume != nil {
-		b.cancelConsume()
-	}
+	b.cancelConsume()
 
 	b.stopReceiving()
 
@@ -418,8 +429,10 @@ func (b *Broker) deleteOne(message *azqueue.DequeuedMessage) error {
 
 // receiveMessage is a method receives a message from specified queue url
 func (b *Broker) receiveMessage() (azqueue.DequeueMessagesResponse, error) {
+	ctx, cancel := context.WithTimeout(b.consumeCtx, receiveCallTimeout)
+	defer cancel()
 	visibilityTimeoutS := int32(b.cfg.VisibilityTimeout.Seconds())
-	result, err := b.newQueueClient(b.queueName).DequeueMessage(b.consumeCtx, &azqueue.DequeueMessageOptions{VisibilityTimeout: &visibilityTimeoutS})
+	result, err := b.newQueueClient(b.queueName).DequeueMessage(ctx, &azqueue.DequeueMessageOptions{VisibilityTimeout: &visibilityTimeoutS})
 	if err != nil {
 		return azqueue.DequeueMessagesResponse{}, err
 	}
@@ -461,8 +474,11 @@ func (b *Broker) consumeDeliveries(deliveries <-chan azqueue.DequeueMessagesResp
 	return true, nil
 }
 
-// stopReceiving is a method sending a signal to stopReceivingChan
+// stopReceiving signals the receive loop to stop. The consumeCtx.Done() case keeps
+// this from blocking if the loop already exited on cancellation.
 func (b *Broker) stopReceiving() {
-	// Stop the receiving goroutine
-	b.stopReceivingChan <- 1
+	select {
+	case b.stopReceivingChan <- 1:
+	case <-b.consumeCtx.Done():
+	}
 }

--- a/v1/brokers/azure/storage_queue_export_test.go
+++ b/v1/brokers/azure/storage_queue_export_test.go
@@ -24,6 +24,7 @@ func NewTestBroker() *Broker {
 		cfg:               *cnf.Azure,
 		queueName:         cnf.DefaultQueue,
 		newQueueClient:    func(name string) queueClient { return nil },
+		consumeCtx:        context.Background(),
 	}
 }
 

--- a/v1/brokers/azure/storage_queue_export_test.go
+++ b/v1/brokers/azure/storage_queue_export_test.go
@@ -16,7 +16,7 @@ func NewTestBroker() *Broker {
 		DefaultQueue: "test_queue",
 		Azure:        &config.AzureConfig{},
 	}
-	return &Broker{
+	b := &Broker{
 		Broker:            common.NewBroker(cnf),
 		processingWG:      sync.WaitGroup{},
 		receivingWG:       sync.WaitGroup{},
@@ -24,8 +24,9 @@ func NewTestBroker() *Broker {
 		cfg:               *cnf.Azure,
 		queueName:         cnf.DefaultQueue,
 		newQueueClient:    func(name string) queueClient { return nil },
-		consumeCtx:        context.Background(),
 	}
+	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
+	return b
 }
 
 func (b *Broker) SetQueueClientFactoryForTest(fn func(string) queueClient) {

--- a/v1/brokers/azure/storage_queue_test.go
+++ b/v1/brokers/azure/storage_queue_test.go
@@ -216,6 +216,25 @@ func TestStopConsuming_CancelsBlockedReceive(t *testing.T) {
 	}
 }
 
+// TestDeleteOne_UsesBoundedContext verifies deleteOne bounds its DeleteMessage call with a
+// deadline. The undecodable message at DequeueCount 15 drives the decode-failure delete path.
+func TestDeleteOne_UsesBoundedContext(t *testing.T) {
+	var deleteHadDeadline bool
+	client := &azure.MockClient{
+		DeleteFunc: func(ctx context.Context, _, _ string, _ *azqueue.DeleteMessageOptions) (azqueue.DeleteMessageResponse, error) {
+			_, deleteHadDeadline = ctx.Deadline()
+			return azqueue.DeleteMessageResponse{}, nil
+		},
+	}
+
+	broker := azure.NewTestBroker()
+	broker.SetMockClientForTest(client)
+
+	err := broker.ConsumeOneForTest(dlqTestDelivery(15, "not valid json"), nil)
+	require.NoError(t, err)
+	assert.True(t, deleteHadDeadline, "deleteOne must bound its DeleteMessage call with a deadline")
+}
+
 // dlqTestDelivery builds a single-message DequeueMessagesResponse for DLQ tests.
 func dlqTestDelivery(dequeueCount int64, body string) azqueue.DequeueMessagesResponse {
 	msgID := "test-msg-id"

--- a/v1/brokers/azure/storage_queue_test.go
+++ b/v1/brokers/azure/storage_queue_test.go
@@ -3,6 +3,7 @@ package azure_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -155,6 +156,64 @@ func TestStartConsuming_V1_ProcessesTask(t *testing.T) {
 
 func TestStartConsuming_V2_ProcessesTask(t *testing.T) {
 	testStartConsumingProcessesTask(t, newTestV2Pool(1))
+}
+
+// TestStopConsuming_CancelsBlockedReceive verifies StopConsuming cancels the receive
+// context so an in-flight DequeueMessage unblocks instead of holding shutdown until the
+// call returns on its own.
+func TestStopConsuming_CancelsBlockedReceive(t *testing.T) {
+	entered := make(chan struct{})
+	ctxErr := make(chan error, 1)
+	var once sync.Once
+	client := &azure.MockClient{
+		DequeueFunc: func(ctx context.Context, _ *azqueue.DequeueMessageOptions) (azqueue.DequeueMessagesResponse, error) {
+			once.Do(func() { close(entered) })
+			<-ctx.Done()
+			select {
+			case ctxErr <- ctx.Err():
+			default:
+			}
+			return azqueue.DequeueMessagesResponse{}, ctx.Err()
+		},
+	}
+
+	broker := azure.NewTestBroker()
+	broker.SetMockClientForTest(client)
+
+	server, err := machinery.NewServer(&config.Config{
+		Broker:        "eager",
+		DefaultQueue:  "test_queue",
+		ResultBackend: "eager",
+	})
+	require.NoError(t, err)
+	wk := server.NewWorker("cancel-worker", 0)
+
+	go broker.StartConsuming("cancel-tag", newTestV2Pool(1), wk) //nolint:errcheck // test, return value not needed
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("DequeueMessage was never entered")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		broker.StopConsuming()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StopConsuming did not return; blocked dequeue was not cancelled")
+	}
+
+	select {
+	case err := <-ctxErr:
+		require.ErrorIs(t, err, context.Canceled)
+	default:
+		t.Fatal("dequeue did not observe a cancelled context")
+	}
 }
 
 // dlqTestDelivery builds a single-message DequeueMessagesResponse for DLQ tests.

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -281,7 +281,7 @@ func (b *Broker) RetryMessage(signature *tasks.Signature) {
 		VisibilityTimeout: aws.Int64(int64(signature.Delay.Seconds())),
 	}
 
-	// On timeout the message redelivers on its existing visibility timeout rather than this backoff.
+	// If this call times out, the message redelivers on its existing visibility timeout rather than this backoff.
 	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
 	defer cancel()
 	_, err := b.service.ChangeMessageVisibilityWithContext(ctx, visibilityInput)
@@ -414,7 +414,8 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 // deleteOne is a method delete a delivery from AWS SQS
 func (b *Broker) deleteOne(delivery *awssqs.ReceiveMessageOutput) error {
 	qURL := b.defaultQueueURL()
-	// On timeout the completed task's message redelivers after its visibility timeout — at-least-once tolerates it.
+	// If this call times out, the completed task's message redelivers — callers must already
+	// tolerate reprocessing, since the queue doesn't guarantee exactly-once delivery.
 	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
 	defer cancel()
 	_, err := b.service.DeleteMessageWithContext(ctx, &awssqs.DeleteMessageInput{

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -59,6 +59,8 @@ type Broker struct {
 // New creates new Broker instance
 func New(cnf *config.Config) iface.Broker {
 	b := &Broker{Broker: common.NewBroker(cnf)}
+	// StartConsuming replaces this with a cancellable context.
+	b.consumeCtx = context.Background()
 	if cnf.SQS != nil && cnf.SQS.Client != nil {
 		// Use provided *SQS client
 		b.service = cnf.SQS.Client
@@ -460,13 +462,8 @@ func (b *Broker) receiveMessage(qURL *string) (*awssqs.ReceiveMessageOutput, err
 	if visibilityTimeout != nil {
 		input.VisibilityTimeout = aws.Int64(int64(*visibilityTimeout))
 	}
-	// consumeCtx is nil only when receiveMessage is called outside StartConsuming (e.g. tests).
-	ctx := b.consumeCtx
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	start := time.Now()
-	result, err := b.service.ReceiveMessageWithContext(ctx, input)
+	result, err := b.service.ReceiveMessageWithContext(b.consumeCtx, input)
 	if rand.Float64() < logSQSReceiveSampleRate {
 		messageID := "unknown"
 		if err == nil && len(result.Messages) > 0 {

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -35,8 +35,12 @@ const (
 	maxReceiveCountBeforeDelete = 15
 	// lifecycleCallTimeout bounds post-receive calls (delete, retry) so a wedged request
 	// can't pin a concurrency slot for the container's life and starve the pool. 30s clears
-	// the SDK retry budget; receive is excluded — it long-polls for WaitTimeSeconds.
+	// the SDK retry budget.
 	lifecycleCallTimeout = 30 * time.Second
+	// receiveCallTimeout bounds a wedged ReceiveMessage. It must exceed the WaitTimeSeconds
+	// long-poll (max 20s) so normal polls aren't cut short; derived from consumeCtx, so
+	// shutdown still cancels it at once.
+	receiveCallTimeout = 30 * time.Second
 )
 
 // Broker represents a AWS SQS broker
@@ -59,8 +63,8 @@ type Broker struct {
 // New creates new Broker instance
 func New(cnf *config.Config) iface.Broker {
 	b := &Broker{Broker: common.NewBroker(cnf)}
-	// StartConsuming replaces this with a cancellable context.
-	b.consumeCtx = context.Background()
+	// StartConsuming replaces this with the per-session cancellable context.
+	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
 	if cnf.SQS != nil && cnf.SQS.Client != nil {
 		// Use provided *SQS client
 		b.service = cnf.SQS.Client
@@ -85,6 +89,8 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 	b.queueUrl = qURL
 
 	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
+	// Release the context on every return path; StopConsuming also cancels eagerly to unblock an in-flight receive.
+	defer b.cancelConsume()
 	b.stopReceivingChan = make(chan int)
 	b.receivingWG.Add(1)
 
@@ -108,11 +114,13 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 				return b.GetRetry(), workerError
 			case <-b.stopReceivingChan:
 				return false, nil
+			case <-b.consumeCtx.Done():
+				// Exit on cancellation alone, without relying on a stopReceivingChan signal.
+				return false, nil
 			case token := <-tokenPool:
 				output, err := b.receiveMessage(qURL)
-				// A cancelled consumeCtx surfaces as a receive error, so cancellation before receive always lands here
 				if err != nil {
-					// On a shutdown cancellation, skip logging; the next pass takes the stopReceivingChan case.
+					// Skip the log if cancellation aborted the receive; the consumeCtx.Done() case ends the loop.
 					if b.consumeCtx.Err() == nil {
 						log.ERROR.Printf("Queue consume error on %s: %s", *qURL, err)
 						if strings.Contains(err.Error(), "AWS.SimpleQueueService.NonExistentQueue") {
@@ -150,11 +158,13 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 			// If someone called b.stopReceivingChannel, they are trying to shut down the process
 			// so we don't want to retry the StartConsuming call
 			return false, nil
+		case <-b.consumeCtx.Done():
+			// Exit on cancellation alone, without relying on a stopReceivingChan signal.
+			return false, nil
 		case <-pool:
 			output, err := b.receiveMessage(qURL)
-			// A cancelled consumeCtx surfaces as a receive error, so cancellation before receive always lands here
 			if err != nil {
-				// On a shutdown cancellation, skip logging; the next pass takes the stopReceivingChan case.
+				// Skip the log if cancellation aborted the receive; the consumeCtx.Done() case ends the loop.
 				if b.consumeCtx.Err() == nil {
 					log.ERROR.Printf("Queue consume error on %s: %s", *qURL, err)
 
@@ -191,9 +201,7 @@ func (b *Broker) StopConsuming() {
 	b.Broker.StopConsuming()
 
 	// Cancel before signalling stop so the in-flight ReceiveMessage long-poll unblocks and the loop sees stopReceivingChan.
-	if b.cancelConsume != nil {
-		b.cancelConsume()
-	}
+	b.cancelConsume()
 
 	b.stopReceiving()
 
@@ -465,8 +473,10 @@ func (b *Broker) receiveMessage(qURL *string) (*awssqs.ReceiveMessageOutput, err
 	if visibilityTimeout != nil {
 		input.VisibilityTimeout = aws.Int64(int64(*visibilityTimeout))
 	}
+	ctx, cancel := context.WithTimeout(b.consumeCtx, receiveCallTimeout)
+	defer cancel()
 	start := time.Now()
-	result, err := b.service.ReceiveMessageWithContext(b.consumeCtx, input)
+	result, err := b.service.ReceiveMessageWithContext(ctx, input)
 	if rand.Float64() < logSQSReceiveSampleRate {
 		messageID := "unknown"
 		if err == nil && len(result.Messages) > 0 {
@@ -508,10 +518,13 @@ func (b *Broker) continueReceivingMessages(qURL *string, deliveries chan *awssqs
 	return true, nil
 }
 
-// stopReceiving is a method sending a signal to stopReceivingChan
+// stopReceiving signals the receive loop to stop. The consumeCtx.Done() case keeps
+// this from blocking if the loop already exited on cancellation.
 func (b *Broker) stopReceiving() {
-	// Stop the receiving goroutine
-	b.stopReceivingChan <- 1
+	select {
+	case b.stopReceivingChan <- 1:
+	case <-b.consumeCtx.Done():
+	}
 }
 
 // getQueueURL is a method returns that returns queueURL first by checking if custom queue was set and usign it

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -110,6 +110,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 				return false, nil
 			case token := <-tokenPool:
 				output, err := b.receiveMessage(qURL)
+				// A cancelled consumeCtx surfaces as a receive error, so cancellation before receive always lands here
 				if err != nil {
 					// On a shutdown cancellation, skip logging; the next pass takes the stopReceivingChan case.
 					if b.consumeCtx.Err() == nil {
@@ -151,6 +152,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 			return false, nil
 		case <-pool:
 			output, err := b.receiveMessage(qURL)
+			// A cancelled consumeCtx surfaces as a receive error, so cancellation before receive always lands here
 			if err != nil {
 				// On a shutdown cancellation, skip logging; the next pass takes the stopReceivingChan case.
 				if b.consumeCtx.Err() == nil {

--- a/v1/brokers/sqs/sqs.go
+++ b/v1/brokers/sqs/sqs.go
@@ -33,6 +33,10 @@ const (
 	// undecodable message is deleted. Set above our standard DLQ threshold (10) so
 	// that queues with a DLQ still route there first.
 	maxReceiveCountBeforeDelete = 15
+	// lifecycleCallTimeout bounds post-receive calls (delete, retry) so a wedged request
+	// can't pin a concurrency slot for the container's life and starve the pool. 30s clears
+	// the SDK retry budget; receive is excluded — it long-polls for WaitTimeSeconds.
+	lifecycleCallTimeout = 30 * time.Second
 )
 
 // Broker represents a AWS SQS broker
@@ -45,6 +49,11 @@ type Broker struct {
 	sess              *session.Session
 	service           sqsiface.SQSAPI
 	queueUrl          *string
+
+	// consumeCtx is cancelled by StopConsuming so an in-flight ReceiveMessage returns
+	// at once instead of holding the loop for the full WaitTimeSeconds long-poll.
+	consumeCtx    context.Context
+	cancelConsume context.CancelFunc
 }
 
 // New creates new Broker instance
@@ -73,6 +82,7 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 	//save it so that it can be used later when attempting to delete task
 	b.queueUrl = qURL
 
+	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
 	b.stopReceivingChan = make(chan int)
 	b.receivingWG.Add(1)
 
@@ -99,9 +109,12 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 			case token := <-tokenPool:
 				output, err := b.receiveMessage(qURL)
 				if err != nil {
-					log.ERROR.Printf("Queue consume error on %s: %s", *qURL, err)
-					if strings.Contains(err.Error(), "AWS.SimpleQueueService.NonExistentQueue") {
-						time.Sleep(30 * time.Second)
+					// On a shutdown cancellation, skip logging; the next pass takes the stopReceivingChan case.
+					if b.consumeCtx.Err() == nil {
+						log.ERROR.Printf("Queue consume error on %s: %s", *qURL, err)
+						if strings.Contains(err.Error(), "AWS.SimpleQueueService.NonExistentQueue") {
+							time.Sleep(30 * time.Second)
+						}
 					}
 					token.Return()
 				} else if len(output.Messages) == 0 {
@@ -137,11 +150,14 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 		case <-pool:
 			output, err := b.receiveMessage(qURL)
 			if err != nil {
-				log.ERROR.Printf("Queue consume error on %s: %s", *qURL, err)
+				// On a shutdown cancellation, skip logging; the next pass takes the stopReceivingChan case.
+				if b.consumeCtx.Err() == nil {
+					log.ERROR.Printf("Queue consume error on %s: %s", *qURL, err)
 
-				// Avoid repeating this
-				if strings.Contains(err.Error(), "AWS.SimpleQueueService.NonExistentQueue") {
-					time.Sleep(30 * time.Second)
+					// Avoid repeating this
+					if strings.Contains(err.Error(), "AWS.SimpleQueueService.NonExistentQueue") {
+						time.Sleep(30 * time.Second)
+					}
 				}
 				//return back to pool right away
 				concurrency.Return()
@@ -169,6 +185,11 @@ func (b *Broker) StartConsuming(consumerTag string, concurrency iface.Resizeable
 // StopConsuming quits the loop
 func (b *Broker) StopConsuming() {
 	b.Broker.StopConsuming()
+
+	// Cancel before signalling stop so the in-flight ReceiveMessage long-poll unblocks and the loop sees stopReceivingChan.
+	if b.cancelConsume != nil {
+		b.cancelConsume()
+	}
 
 	b.stopReceiving()
 
@@ -256,7 +277,10 @@ func (b *Broker) RetryMessage(signature *tasks.Signature) {
 		VisibilityTimeout: aws.Int64(int64(signature.Delay.Seconds())),
 	}
 
-	_, err := b.service.ChangeMessageVisibility(visibilityInput)
+	// On timeout the message redelivers on its existing visibility timeout rather than this backoff.
+	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
+	defer cancel()
+	_, err := b.service.ChangeMessageVisibilityWithContext(ctx, visibilityInput)
 	if err != nil {
 		log.ERROR.Printf("ignoring error attempting to change visibility timeout. will re-attempt after default period. task %s (%s)", signature.UUID, signature.Name)
 	}
@@ -386,7 +410,10 @@ func (b *Broker) consumeOne(delivery *awssqs.ReceiveMessageOutput, taskProcessor
 // deleteOne is a method delete a delivery from AWS SQS
 func (b *Broker) deleteOne(delivery *awssqs.ReceiveMessageOutput) error {
 	qURL := b.defaultQueueURL()
-	_, err := b.service.DeleteMessage(&awssqs.DeleteMessageInput{
+	// On timeout the completed task's message redelivers after its visibility timeout — at-least-once tolerates it.
+	ctx, cancel := context.WithTimeout(context.Background(), lifecycleCallTimeout)
+	defer cancel()
+	_, err := b.service.DeleteMessageWithContext(ctx, &awssqs.DeleteMessageInput{
 		QueueUrl:      qURL,
 		ReceiptHandle: delivery.Messages[0].ReceiptHandle,
 	})
@@ -433,8 +460,13 @@ func (b *Broker) receiveMessage(qURL *string) (*awssqs.ReceiveMessageOutput, err
 	if visibilityTimeout != nil {
 		input.VisibilityTimeout = aws.Int64(int64(*visibilityTimeout))
 	}
+	// consumeCtx is nil only when receiveMessage is called outside StartConsuming (e.g. tests).
+	ctx := b.consumeCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	start := time.Now()
-	result, err := b.service.ReceiveMessage(input)
+	result, err := b.service.ReceiveMessageWithContext(ctx, input)
 	if rand.Float64() < logSQSReceiveSampleRate {
 		messageID := "unknown"
 		if err == nil && len(result.Messages) > 0 {

--- a/v1/brokers/sqs/sqs_export_test.go
+++ b/v1/brokers/sqs/sqs_export_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 
@@ -39,8 +40,16 @@ func (f *FakeSQS) ReceiveMessage(*awssqs.ReceiveMessageInput) (*awssqs.ReceiveMe
 	return ReceiveMessageOutput, nil
 }
 
+func (f *FakeSQS) ReceiveMessageWithContext(_ aws.Context, in *awssqs.ReceiveMessageInput, _ ...request.Option) (*awssqs.ReceiveMessageOutput, error) {
+	return f.ReceiveMessage(in)
+}
+
 func (f *FakeSQS) DeleteMessage(*awssqs.DeleteMessageInput) (*awssqs.DeleteMessageOutput, error) {
 	return &awssqs.DeleteMessageOutput{}, nil
+}
+
+func (f *FakeSQS) DeleteMessageWithContext(_ aws.Context, in *awssqs.DeleteMessageInput, _ ...request.Option) (*awssqs.DeleteMessageOutput, error) {
+	return f.DeleteMessage(in)
 }
 
 type ErrorSQS struct {
@@ -57,9 +66,17 @@ func (e *ErrorSQS) ReceiveMessage(*awssqs.ReceiveMessageInput) (*awssqs.ReceiveM
 	return nil, err
 }
 
+func (e *ErrorSQS) ReceiveMessageWithContext(_ aws.Context, in *awssqs.ReceiveMessageInput, _ ...request.Option) (*awssqs.ReceiveMessageOutput, error) {
+	return e.ReceiveMessage(in)
+}
+
 func (e *ErrorSQS) DeleteMessage(*awssqs.DeleteMessageInput) (*awssqs.DeleteMessageOutput, error) {
 	err := errors.New("this is an error")
 	return nil, err
+}
+
+func (e *ErrorSQS) DeleteMessageWithContext(_ aws.Context, in *awssqs.DeleteMessageInput, _ ...request.Option) (*awssqs.DeleteMessageOutput, error) {
+	return e.DeleteMessage(in)
 }
 
 func init() {

--- a/v1/brokers/sqs/sqs_export_test.go
+++ b/v1/brokers/sqs/sqs_export_test.go
@@ -1,6 +1,7 @@
 package sqs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -142,6 +143,7 @@ func NewTestBroker() *Broker {
 		processingWG:      sync.WaitGroup{},
 		receivingWG:       sync.WaitGroup{},
 		stopReceivingChan: make(chan int),
+		consumeCtx:        context.Background(),
 	}
 }
 
@@ -157,6 +159,7 @@ func NewTestBrokerWithService(service sqsiface.SQSAPI) *Broker {
 		processingWG:      sync.WaitGroup{},
 		receivingWG:       sync.WaitGroup{},
 		stopReceivingChan: make(chan int),
+		consumeCtx:        context.Background(),
 	}
 }
 
@@ -175,6 +178,7 @@ func NewTestErrorBroker() *Broker {
 		processingWG:      sync.WaitGroup{},
 		receivingWG:       sync.WaitGroup{},
 		stopReceivingChan: make(chan int),
+		consumeCtx:        context.Background(),
 	}
 }
 

--- a/v1/brokers/sqs/sqs_export_test.go
+++ b/v1/brokers/sqs/sqs_export_test.go
@@ -136,15 +136,16 @@ func NewTestBroker() *Broker {
 	}))
 
 	svc := new(FakeSQS)
-	return &Broker{
+	b := &Broker{
 		Broker:            common.NewBroker(cnf),
 		sess:              sess,
 		service:           svc,
 		processingWG:      sync.WaitGroup{},
 		receivingWG:       sync.WaitGroup{},
 		stopReceivingChan: make(chan int),
-		consumeCtx:        context.Background(),
 	}
+	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
+	return b
 }
 
 func NewTestBrokerWithService(service sqsiface.SQSAPI) *Broker {
@@ -152,15 +153,16 @@ func NewTestBrokerWithService(service sqsiface.SQSAPI) *Broker {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
-	return &Broker{
+	b := &Broker{
 		Broker:            common.NewBroker(cnf),
 		sess:              sess,
 		service:           service,
 		processingWG:      sync.WaitGroup{},
 		receivingWG:       sync.WaitGroup{},
 		stopReceivingChan: make(chan int),
-		consumeCtx:        context.Background(),
 	}
+	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
+	return b
 }
 
 func NewTestErrorBroker() *Broker {
@@ -171,15 +173,16 @@ func NewTestErrorBroker() *Broker {
 	}))
 
 	errSvc := new(ErrorSQS)
-	return &Broker{
+	b := &Broker{
 		Broker:            common.NewBroker(cnf),
 		sess:              sess,
 		service:           errSvc,
 		processingWG:      sync.WaitGroup{},
 		receivingWG:       sync.WaitGroup{},
 		stopReceivingChan: make(chan int),
-		consumeCtx:        context.Background(),
 	}
+	b.consumeCtx, b.cancelConsume = context.WithCancel(context.Background())
+	return b
 }
 
 func (b *Broker) ConsumeForTest(deliveries <-chan *awssqs.ReceiveMessageOutput, taskProcessor iface.TaskProcessor, concurrency iface.ResizeablePool) error {

--- a/v1/brokers/sqs/sqs_test.go
+++ b/v1/brokers/sqs/sqs_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/RichardKnop/machinery/v1/brokers/iface"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -153,6 +154,12 @@ type deleteTrackingSQS struct {
 func (f *deleteTrackingSQS) DeleteMessage(*awssqs.DeleteMessageInput) (*awssqs.DeleteMessageOutput, error) {
 	f.deleted = true
 	return &awssqs.DeleteMessageOutput{}, nil
+}
+
+// DeleteMessageWithContext delegates to this type's own DeleteMessage; the inherited
+// FakeSQS variant would bypass the deleted-tracking override (Go embedding isn't virtual).
+func (f *deleteTrackingSQS) DeleteMessageWithContext(_ aws.Context, in *awssqs.DeleteMessageInput, _ ...request.Option) (*awssqs.DeleteMessageOutput, error) {
+	return f.DeleteMessage(in)
 }
 
 func invalidJSONMessage(receiveCount string) *awssqs.ReceiveMessageOutput {
@@ -347,6 +354,12 @@ func (f *taskFakeSQS) ReceiveMessage(*awssqs.ReceiveMessageInput) (*awssqs.Recei
 	return f.output, nil
 }
 
+// ReceiveMessageWithContext delegates to this type's own ReceiveMessage; the inherited
+// FakeSQS variant would return the global fixture instead of f.output.
+func (f *taskFakeSQS) ReceiveMessageWithContext(_ aws.Context, in *awssqs.ReceiveMessageInput, _ ...request.Option) (*awssqs.ReceiveMessageOutput, error) {
+	return f.ReceiveMessage(in)
+}
+
 // testV2Pool wraps a ResizeablePool to implement iface.ResizeablePoolV2 for testing.
 type testV2Pool struct {
 	iface.ResizeablePool
@@ -426,6 +439,87 @@ func TestStartConsuming_V1_ProcessesTask(t *testing.T) {
 
 func TestStartConsuming_V2_ProcessesTask(t *testing.T) {
 	testStartConsumingProcessesTask(t, newTestV2Pool(1))
+}
+
+// blockingReceiveSQS parks in ReceiveMessage until its context is cancelled (idle queue mid-long-poll at shutdown).
+type blockingReceiveSQS struct {
+	sqs.FakeSQS
+	entered chan struct{}
+	ctxErr  chan error
+	once    sync.Once
+}
+
+func (f *blockingReceiveSQS) ReceiveMessageWithContext(ctx aws.Context, _ *awssqs.ReceiveMessageInput, _ ...request.Option) (*awssqs.ReceiveMessageOutput, error) {
+	f.once.Do(func() { close(f.entered) })
+	<-ctx.Done()
+	select {
+	case f.ctxErr <- ctx.Err():
+	default:
+	}
+	return nil, ctx.Err()
+}
+
+// TestStopConsuming_CancelsBlockedReceive verifies StopConsuming cancels the receive
+// context so an in-flight ReceiveMessage unblocks instead of holding shutdown for the
+// full WaitTimeSeconds long-poll.
+func TestStopConsuming_CancelsBlockedReceive(t *testing.T) {
+	fake := &blockingReceiveSQS{entered: make(chan struct{}), ctxErr: make(chan error, 1)}
+	broker := sqs.NewTestBrokerWithService(fake)
+
+	localCnf := *cnf
+	localCnf.ResultBackend = "eager"
+	server, err := machinery.NewServer(&localCnf)
+	require.NoError(t, err)
+	wk := server.NewWorker("cancel-worker", 0)
+
+	go broker.StartConsuming("cancel-tag", newTestV2Pool(1), wk) //nolint:errcheck // test, return value not needed
+
+	select {
+	case <-fake.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReceiveMessage was never entered")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		broker.StopConsuming()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StopConsuming did not return; blocked receive was not cancelled")
+	}
+
+	select {
+	case err := <-fake.ctxErr:
+		require.ErrorIs(t, err, context.Canceled)
+	default:
+		t.Fatal("receive did not observe a cancelled context")
+	}
+}
+
+// deadlineCaptureSQS records whether deleteOne bounded its SQS call with a deadline.
+type deadlineCaptureSQS struct {
+	sqs.FakeSQS
+	deleteHadDeadline bool
+}
+
+func (f *deadlineCaptureSQS) DeleteMessageWithContext(ctx aws.Context, _ *awssqs.DeleteMessageInput, _ ...request.Option) (*awssqs.DeleteMessageOutput, error) {
+	_, f.deleteHadDeadline = ctx.Deadline()
+	return &awssqs.DeleteMessageOutput{}, nil
+}
+
+// TestDeleteOne_UsesBoundedContext verifies deleteOne bounds its SQS call with a deadline.
+// The at-threshold undecodable message drives the decode-failure delete path.
+func TestDeleteOne_UsesBoundedContext(t *testing.T) {
+	fakeSvc := &deadlineCaptureSQS{}
+	broker := sqs.NewTestBrokerWithService(fakeSvc)
+
+	err := broker.ConsumeOneForTest(invalidJSONMessage("15"), nil)
+	require.NoError(t, err)
+	assert.True(t, fakeSvc.deleteHadDeadline, "deleteOne must bound its SQS call with a deadline")
 }
 
 func TestPrivateFunc_consumeWithConcurrency(t *testing.T) {


### PR DESCRIPTION
Updates ASQ/SQS clients to use 30-second timeouts for deletion/visibility extension/DLQ insertion (Azure only), and updates them to cancel the Context used for dequeueing messages on shutdown. Prevents a hanging call from occupying a work slot for the container's lifetime, and prevents the brokers from pulling new work while shutting down (wastes an attempt + pushes out the message's visibility, then interrupts processing after the shutdown grace period)

AI usage: written by Claude; reviewed by me